### PR TITLE
Normalize CMS website payload consumption

### DIFF
--- a/src/components/DebugPanel.astro
+++ b/src/components/DebugPanel.astro
@@ -1,204 +1,205 @@
 ---
 import { config } from '../config';
 import { getHttpRequests } from '../services/cms';
+import type { Website } from '../services/cms';
 
 interface Props {
-  websiteData?: any;
+  websiteData?: Website | null;
   articles?: any[];
   additionalInfo?: Record<string, any>;
 }
 
-const { websiteData, articles = [], additionalInfo = {} } = Astro.props;
+const { websiteData, articles = [], additionalInfo = {} } = Astro.props as Props;
 const httpRequests = getHttpRequests();
 ---
 
 {/* Only render debug panel in development */}
 {config.isDevelopment && (
-<div style="position: fixed; bottom: 20px; right: 20px; z-index: 1000; font-family: monospace;">
-  <div id="debug-panel" style="display: none; background: #1f2937; color: white; border-radius: 8px; box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5); max-width: 400px; border: 1px solid #374151;">
-    {/* Header */}
-    <div style="display: flex; align-items: center; justify-content: space-between; padding: 1rem 1rem 0.5rem; border-bottom: 1px solid #374151;">
-      <h4 style="margin: 0; color: #f9fafb; font-size: 0.9rem; display: flex; align-items: center; gap: 0.5rem;">
-        🔧 Debug
-        <span style="font-size: 0.7rem; background: #059669; padding: 0.2rem 0.4rem; border-radius: 3px;">DEV</span>
-      </h4>
-      <button onclick="toggleDebugPanel(false)"
-              style="background: none; border: none; color: #9ca3af; cursor: pointer; font-size: 1.2rem; padding: 0; line-height: 1;">×</button>
-    </div>
-
-    {/* Tabs */}
-    <div style="display: flex; border-bottom: 1px solid #374151;">
-      <button onclick="switchDebugTab('info')" id="tab-info"
-              style="flex: 1; background: #374151; border: none; color: white; padding: 0.5rem; cursor: pointer; font-size: 0.75rem; border-right: 1px solid #4b5563;">
-        Info
-      </button>
-      <button onclick="switchDebugTab('requests')" id="tab-requests"
-              style="flex: 1; background: #1f2937; border: none; color: #9ca3af; padding: 0.5rem; cursor: pointer; font-size: 0.75rem;">
-        HTTP ({httpRequests.length})
-      </button>
-    </div>
-
-    {/* Info Tab Content */}
-    <div id="debug-content-info" style="padding: 1rem; display: grid; gap: 0.5rem; font-size: 0.75rem; max-height: 400px; overflow-y: auto;">
-      <div style="display: flex; justify-content: space-between;">
-        <span style="color: #d1d5db;">ENV:</span>
-        <strong style="color: #10b981;">{config.nodeEnv}</strong>
-      </div>
-      <div style="display: flex; justify-content: space-between;">
-        <span style="color: #d1d5db;">CMS:</span>
-        <strong style="color: #60a5fa; font-size: 0.7rem;">{config.cmsUrl}</strong>
-      </div>
-      <div style="display: flex; justify-content: space-between;">
-        <span style="color: #d1d5db;">API Name:</span>
-        <strong style="color: #fbbf24;">{config.websiteApiName}</strong>
-      </div>
-      <div style="display: flex; justify-content: space-between;">
-        <span style="color: #d1d5db;">Articles:</span>
-        <strong style="color: #f87171;">{articles.length}</strong>
+  <div style="position: fixed; bottom: 20px; right: 20px; z-index: 1000; font-family: monospace;">
+    <div id="debug-panel" style="display: none; background: #1f2937; color: white; border-radius: 8px; box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5); max-width: 400px; border: 1px solid #374151;">
+      {/* Header */}
+      <div style="display: flex; align-items: center; justify-content: space-between; padding: 1rem 1rem 0.5rem; border-bottom: 1px solid #374151;">
+        <h4 style="margin: 0; color: #f9fafb; font-size: 0.9rem; display: flex; align-items: center; gap: 0.5rem;">
+          🔧 Debug
+          <span style="font-size: 0.7rem; background: #059669; padding: 0.2rem 0.4rem; border-radius: 3px;">DEV</span>
+        </h4>
+        <button onclick="toggleDebugPanel(false)"
+          style="background: none; border: none; color: #9ca3af; cursor: pointer; font-size: 1.2rem; padding: 0; line-height: 1;">×</button>
       </div>
 
-      {websiteData && (
-        <>
-          <hr style="border: none; border-top: 1px solid #374151; margin: 0.5rem 0;" />
-          <div style="display: flex; justify-content: space-between;">
-            <span style="color: #d1d5db;">Site Name:</span>
-            <strong style="color: #a78bfa; font-size: 0.7rem;">{websiteData.name}</strong>
-          </div>
-          <div style="display: flex; justify-content: space-between;">
-            <span style="color: #d1d5db;">Base URL:</span>
-            <strong style="color: #34d399; font-size: 0.65rem;">{websiteData.baseUrl}</strong>
-          </div>
-          <div style="display: flex; justify-content: space-between;">
-            <span style="color: #d1d5db;">Locale:</span>
-            <strong style="color: #fbbf24;">{websiteData.defaultLocale}</strong>
-          </div>
-          <div style="display: flex; justify-content: space-between;">
-            <span style="color: #d1d5db;">Locales:</span>
-            <strong style="color: #f87171; font-size: 0.7rem;">{websiteData.locales.join(', ')}</strong>
-          </div>
-          <div style="display: flex; justify-content: space-between;">
-            <span style="color: #d1d5db;">Brand:</span>
-            <strong style={`color: ${websiteData.brandColor}; font-size: 0.7rem;`}>{websiteData.brandColor}</strong>
-          </div>
-          <div style="display: flex; justify-content: space-between;">
-            <span style="color: #d1d5db;">Updated:</span>
-            <strong style="color: #9ca3af; font-size: 0.65rem;">{new Date(websiteData.updatedAt).toLocaleDateString()}</strong>
-          </div>
-        </>
-      )}
+      {/* Tabs */}
+      <div style="display: flex; border-bottom: 1px solid #374151;">
+        <button onclick="switchDebugTab('info')" id="tab-info"
+          style="flex: 1; background: #374151; border: none; color: white; padding: 0.5rem; cursor: pointer; font-size: 0.75rem; border-right: 1px solid #4b5563;">
+          Info
+        </button>
+        <button onclick="switchDebugTab('requests')" id="tab-requests"
+          style="flex: 1; background: #1f2937; border: none; color: #9ca3af; padding: 0.5rem; cursor: pointer; font-size: 0.75rem;">
+          HTTP ({httpRequests.length})
+        </button>
+      </div>
 
-      {/* Additional Info */}
-      {Object.keys(additionalInfo).length > 0 && (
-        <>
-          <hr style="border: none; border-top: 1px solid #374151; margin: 0.5rem 0;" />
-          {Object.entries(additionalInfo).map(([key, value]) => (
-            <div key={key} style="display: flex; justify-content: space-between;">
-              <span style="color: #d1d5db;">{key}:</span>
-              <strong style="color: #a78bfa; font-size: 0.7rem;">{String(value)}</strong>
+      {/* Info Tab Content */}
+      <div id="debug-content-info" style="padding: 1rem; display: grid; gap: 0.5rem; font-size: 0.75rem; max-height: 400px; overflow-y: auto;">
+        <div style="display: flex; justify-content: space-between;">
+          <span style="color: #d1d5db;">ENV:</span>
+          <strong style="color: #10b981;">{config.nodeEnv}</strong>
+        </div>
+        <div style="display: flex; justify-content: space-between;">
+          <span style="color: #d1d5db;">CMS:</span>
+          <strong style="color: #60a5fa; font-size: 0.7rem;">{config.cmsUrl}</strong>
+        </div>
+        <div style="display: flex; justify-content: space-between;">
+          <span style="color: #d1d5db;">API Name:</span>
+          <strong style="color: #fbbf24;">{config.websiteApiName}</strong>
+        </div>
+        <div style="display: flex; justify-content: space-between;">
+          <span style="color: #d1d5db;">Articles:</span>
+          <strong style="color: #f87171;">{articles.length}</strong>
+        </div>
+
+        {websiteData && (
+          <>
+            <hr style="border: none; border-top: 1px solid #374151; margin: 0.5rem 0;" />
+            <div style="display: flex; justify-content: space-between;">
+              <span style="color: #d1d5db;">Site Name:</span>
+              <strong style="color: #a78bfa; font-size: 0.7rem;">{websiteData.name}</strong>
             </div>
-          ))}
-        </>
-      )}
+            <div style="display: flex; justify-content: space-between;">
+              <span style="color: #d1d5db;">Default Locale:</span>
+              <strong style="color: #fbbf24;">{websiteData.defaultLocale}</strong>
+            </div>
+            <div style="display: flex; justify-content: space-between;">
+              <span style="color: #d1d5db;">Locales:</span>
+              <strong style="color: #f87171; font-size: 0.7rem;">{websiteData.supportedLocales.join(', ')}</strong>
+            </div>
+            <div style="display: flex; justify-content: space-between;">
+              <span style="color: #d1d5db;">Theme Primary:</span>
+              <strong style={`color: ${websiteData.theme?.brandColor || websiteData.theme?.palette?.primary || '#f97316'}; font-size: 0.7rem;`}>
+                {websiteData.theme?.brandColor || websiteData.theme?.palette?.primary || 'n/a'}
+              </strong>
+            </div>
+            <div style="display: flex; justify-content: space-between;">
+              <span style="color: #d1d5db;">Updated:</span>
+              <strong style="color: #9ca3af; font-size: 0.65rem;">{new Date(websiteData.updatedAt).toLocaleDateString()}</strong>
+            </div>
+          </>
+        )}
 
-      <hr style="border: none; border-top: 1px solid #374151; margin: 0.5rem 0;" />
-      <div style="display: flex; justify-content: space-between;">
-        <span style="color: #d1d5db;">Build:</span>
-        <strong style="color: #9ca3af; font-size: 0.65rem;">{new Date().toLocaleTimeString()}</strong>
+        {/* Additional Info */}
+        {Object.keys(additionalInfo).length > 0 && (
+          <>
+            <hr style="border: none; border-top: 1px solid #374151; margin: 0.5rem 0;" />
+            {Object.entries(additionalInfo).map(([key, value]) => (
+              <div key={key} style="display: flex; justify-content: space-between;">
+                <span style="color: #d1d5db;">{key}:</span>
+                <strong style="color: #a78bfa; font-size: 0.7rem;">{String(value)}</strong>
+              </div>
+            ))}
+          </>
+        )}
+
+        <hr style="border: none; border-top: 1px solid #374151; margin: 0.5rem 0;" />
+        <div style="display: flex; justify-content: space-between;">
+          <span style="color: #d1d5db;">Build:</span>
+          <strong style="color: #9ca3af; font-size: 0.65rem;">{new Date().toLocaleTimeString()}</strong>
+        </div>
       </div>
-    </div>
 
-    {/* HTTP Requests Tab Content */}
-    <div id="debug-content-requests" style="padding: 1rem; display: none; font-size: 0.75rem; max-height: 400px; overflow-y: auto;">
-      {httpRequests.length > 0 ? (
-        <div style="display: grid; gap: 0.75rem;">
-          {httpRequests.map((req, index) => (
-            <div key={index} style="border: 1px solid #374151; border-radius: 4px; padding: 0.75rem; background: #111827;">
-              <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.5rem;">
-                <span style={`color: ${req.status >= 200 && req.status < 300 ? '#10b981' : req.status >= 400 ? '#f87171' : '#fbbf24'}; font-weight: bold;`}>
-                  {req.method} {req.status}
-                </span>
-                <span style="color: #9ca3af; font-size: 0.65rem;">
-                  {req.duration}ms
-                </span>
-              </div>
-              <div style="color: #60a5fa; font-size: 0.65rem; margin-bottom: 0.25rem; word-break: break-all;">
-                {req.url}
-              </div>
-              <div style="color: #9ca3af; font-size: 0.6rem;">
-                {req.timestamp.toLocaleTimeString()}
-              </div>
-              {req.error && (
-                <div style="color: #f87171; font-size: 0.65rem; margin-top: 0.25rem;">
-                  ❌ {req.error}
+      {/* HTTP Requests Tab Content */}
+      <div id="debug-content-requests" style="padding: 1rem; display: none; font-size: 0.75rem; max-height: 400px; overflow-y: auto;">
+        {httpRequests.length > 0 ? (
+          <div style="display: grid; gap: 0.75rem;">
+            {httpRequests.map((req, index) => (
+              <div key={index} style="border: 1px solid #374151; border-radius: 4px; padding: 0.75rem; background: #111827;">
+                <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.5rem;">
+                  <span style={`color: ${req.status >= 200 && req.status < 300 ? '#10b981' : req.status >= 400 ? '#f87171' : '#fbbf24'}; font-weight: bold;`}>
+                    {req.method} {req.status}
+                  </span>
+                  <span style="color: #9ca3af; font-size: 0.65rem;">
+                    {req.duration}ms
+                  </span>
                 </div>
-              )}
-            </div>
-          ))}
-        </div>
-      ) : (
-        <div style="color: #9ca3af; text-align: center; padding: 2rem;">
-          No HTTP requests recorded
-        </div>
-      )}
+                <div style="color: #60a5fa; font-size: 0.65rem; margin-bottom: 0.25rem; word-break: break-all;">
+                  {req.url}
+                </div>
+                <div style="color: #9ca3af; font-size: 0.6rem;">
+                  {req.timestamp.toLocaleTimeString()}
+                </div>
+                {req.error && (
+                  <div style="color: #f87171; font-size: 0.65rem; margin-top: 0.25rem;">
+                    ❌ {req.error}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div style="color: #9ca3af; text-align: center; padding: 2rem;">
+            No HTTP requests recorded
+          </div>
+        )}
+      </div>
     </div>
-  </div>
 
-  {/* Debug Toggle Button */}
-  <button id="debug-toggle" onclick="toggleDebugPanel(true)"
-          style="position: absolute; bottom: 0; right: 0; display: flex; align-items: center; justify-content: center; background: #374151; border: 1px solid #4b5563; color: white; width: 48px; height: 48px; border-radius: 50%; cursor: pointer; box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3); font-size: 1.2rem;">
-    🔧
-  </button>
+    {/* Debug Toggle Button */}
+    <button id="debug-toggle" onclick="toggleDebugPanel(true)"
+      style="position: absolute; bottom: 0; right: 0; display: flex; align-items: center; justify-content: center; background: #374151; border: 1px solid #4b5563; color: white; width: 48px; height: 48px; border-radius: 50%; cursor: pointer; box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3); font-size: 1.2rem;">
+      🔧
+    </button>
 
-  <script>
-    window.toggleDebugPanel = function(show) {
-      const panel = document.getElementById('debug-panel');
-      const toggle = document.getElementById('debug-toggle');
+    <script>
+      window.toggleDebugPanel = function(show) {
+        const panel = document.getElementById('debug-panel');
+        const toggle = document.getElementById('debug-toggle');
 
-      if (show) {
-        if (panel) panel.style.display = 'block';
-        if (toggle) toggle.style.display = 'none';
-      } else {
-        if (panel) panel.style.display = 'none';
-        if (toggle) toggle.style.display = 'block';
-      }
-    }
-
-    window.switchDebugTab = function(tab) {
-      // Hide all tab contents
-      const infoContent = document.getElementById('debug-content-info');
-      const requestsContent = document.getElementById('debug-content-requests');
-
-      // Reset all tab buttons
-      const infoTab = document.getElementById('tab-info');
-      const requestsTab = document.getElementById('tab-requests');
-
-      if (infoContent) infoContent.style.display = 'none';
-      if (requestsContent) requestsContent.style.display = 'none';
-
-      if (infoTab) {
-        infoTab.style.background = '#1f2937';
-        infoTab.style.color = '#9ca3af';
-      }
-      if (requestsTab) {
-        requestsTab.style.background = '#1f2937';
-        requestsTab.style.color = '#9ca3af';
+        if (show) {
+          if (panel) panel.style.display = 'block';
+          if (toggle) toggle.style.display = 'none';
+        } else {
+          if (panel) panel.style.display = 'none';
+          if (toggle) toggle.style.display = 'block';
+        }
       }
 
-      // Show selected tab
-      if (tab === 'info') {
-        if (infoContent) infoContent.style.display = 'grid';
+      window.switchDebugTab = function(tab) {
+        // Hide all tab contents
+        const infoContent = document.getElementById('debug-content-info');
+        const requestsContent = document.getElementById('debug-content-requests');
+
+        // Reset all tab buttons
+        const infoTab = document.getElementById('tab-info');
+        const requestsTab = document.getElementById('tab-requests');
+
+        if (infoContent) infoContent.style.display = 'none';
+        if (requestsContent) requestsContent.style.display = 'none';
+
         if (infoTab) {
-          infoTab.style.background = '#374151';
-          infoTab.style.color = 'white';
+          infoTab.style.background = '#1f2937';
+          infoTab.style.color = '#9ca3af';
         }
-      } else if (tab === 'requests') {
-        if (requestsContent) requestsContent.style.display = 'block';
         if (requestsTab) {
-          requestsTab.style.background = '#374151';
-          requestsTab.style.color = 'white';
+          requestsTab.style.background = '#1f2937';
+          requestsTab.style.color = '#9ca3af';
+        }
+
+        // Show selected tab
+        if (tab === 'info') {
+          if (infoContent) infoContent.style.display = 'grid';
+          if (infoTab) {
+            infoTab.style.background = '#374151';
+            infoTab.style.color = 'white';
+          }
+        } else if (tab === 'requests') {
+          if (requestsContent) requestsContent.style.display = 'block';
+          if (requestsTab) {
+            requestsTab.style.background = '#374151';
+            requestsTab.style.color = 'white';
+          }
         }
       }
-    }
-  </script>
-</div>
+
+      window.toggleDebugPanel(false);
+    </script>
+  </div>
 )}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,47 +1,29 @@
 ---
 import { config } from '../config';
+import type { Website } from '../services/cms';
+import { resolveCmsAssetUrl } from '../services/cms';
 
 interface Props {
   title?: string;
-  websiteData?: {
-    name?: string;
-    baseUrl?: string;
-    locales?: string[];
-    defaultLocale?: string;
-    logo?: {
-      url: string;
-      alternativeText?: string;
-    };
-    brandColors?: Array<{
-      primary?: string;
-      secondary?: string;
-      background?: string;
-      text?: string;
-    }>;
-    favicon?: {
-      url: string;
-      alternativeText: string;
-    };
-  };
+  websiteData?: Website | null;
 }
 
-const { title, websiteData } = Astro.props;
-const siteName = websiteData?.name || 'Astro Site';
-const pageTitle = title ? `${title} | ${siteName}` : siteName;
+const { title, websiteData } = Astro.props as Props;
+const siteName = websiteData?.header?.brandDisplayName || websiteData?.name || 'Multisite CMS';
+const seoTitle = websiteData?.seoDefaults?.metaTitle || siteName;
+const pageTitle = title ? `${title} | ${siteName}` : seoTitle;
+const metaDescription = websiteData?.seoDefaults?.metaDescription || `Content managed by Strapi for ${siteName}.`;
+const htmlLang = websiteData?.locale || websiteData?.defaultLocale || 'en';
 
-function resolveAssetUrl(path?: string | null) {
-  if (!path) return null;
-  if (path.startsWith('http')) return path;
-  if (!config.cmsUrl) {
-    console.warn('Missing CMS_URL env. Returning relative asset path for logo/favicon.');
-    return path;
-  }
-  const normalizedBase = config.cmsUrl.replace(/\/$/, '');
-  return `${normalizedBase}${path}`;
-}
-
-const faviconUrl = resolveAssetUrl(websiteData?.favicon?.url) || '/favicon.svg';
-const currentYear = new Date().getFullYear();
+const palette = {
+  primary: websiteData?.theme?.palette?.primary || websiteData?.theme?.brandColor || '#FF8A00',
+  secondary: websiteData?.theme?.palette?.secondary || '#0EA5B5',
+  accent: websiteData?.theme?.palette?.accent || '#FFD141',
+  background: websiteData?.theme?.palette?.background || '#FFFFFF',
+  surface: websiteData?.theme?.palette?.surface || '#F6F7F9',
+  muted: websiteData?.theme?.palette?.muted || '#94A3B8',
+  neutral: websiteData?.theme?.palette?.neutral || '#111827',
+};
 
 function createVarStyle(map: Record<string, string | undefined>, context: string): string {
   const segments: string[] = [];
@@ -52,39 +34,41 @@ function createVarStyle(map: Record<string, string | undefined>, context: string
       missing.push(key);
       continue;
     }
+
     segments.push(`--${key}: ${value};`);
   }
 
   if (missing.length > 0) {
-    console.warn(`Missing brand color values for ${missing.join(', ')} in ${context}. Update the CMS brandColors configuration to keep the layout in sync.`);
+    console.warn(`Missing theme values for ${missing.join(', ')} in ${context}. Update the CMS theme palette to keep the layout in sync.`);
   }
 
   return segments.join(' ');
 }
 
-const brandPalette = websiteData?.brandColors?.[0];
-
-if (!brandPalette) {
-  console.warn('No brandColors found in CMS response. Footer and layout styling will fall back to browser defaults until values are provided.');
-}
-
 const brandStyles = createVarStyle(
   {
-    'brand-primary': brandPalette?.primary,
-    'brand-secondary': brandPalette?.secondary,
-    'brand-background': brandPalette?.background,
-    'brand-text': brandPalette?.text,
+    'brand-primary': palette.primary,
+    'brand-secondary': palette.secondary,
+    'brand-accent': palette.accent,
+    'brand-background': palette.background,
+    'brand-surface': palette.surface,
+    'brand-muted': palette.muted,
+    'brand-neutral': palette.neutral,
   },
-  'brandColors[0]'
+  'theme.palette',
 );
-const logoUrl = resolveAssetUrl(websiteData?.logo?.url);
+
+const logoUrl = resolveCmsAssetUrl(websiteData?.brand?.logo);
+const faviconUrl = resolveCmsAssetUrl(websiteData?.brand?.favicon) || '/favicon.svg';
+const footer = websiteData?.footer;
+const currentYear = new Date().getFullYear();
 ---
 
 <!doctype html>
-<html lang="en">
+<html lang={htmlLang}>
   <head>
     <meta charset="UTF-8" />
-    <meta name="description" content="Astro description" />
+    <meta name="description" content={metaDescription} />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" href={faviconUrl} />
     <meta name="generator" content={Astro.generator} />
@@ -93,6 +77,7 @@ const logoUrl = resolveAssetUrl(websiteData?.logo?.url);
       :root {
         color-scheme: light;
       }
+
       body {
         font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
         margin: 0;
@@ -100,58 +85,108 @@ const logoUrl = resolveAssetUrl(websiteData?.logo?.url);
         display: flex;
         flex-direction: column;
         background: var(--brand-background);
-        color: var(--brand-text);
+        color: var(--brand-neutral);
       }
+
+      a {
+        color: inherit;
+      }
+
       .page-main {
         flex: 1 0 auto;
       }
+
       .site-footer {
         background: var(--brand-primary);
-        color: var(--brand-text);
+        color: var(--brand-neutral);
         padding: 3rem 1.5rem;
       }
+
       .footer-inner {
         max-width: 960px;
         margin: 0 auto;
-        display: flex;
-        flex-direction: column;
-        gap: 1.5rem;
+        display: grid;
+        gap: 2rem;
       }
+
       .footer-brand {
         display: flex;
         align-items: center;
         gap: 1rem;
       }
+
       .footer-logo {
         height: 36px;
         width: auto;
         flex-shrink: 0;
       }
+
       .footer-brand-copy {
         display: flex;
         flex-direction: column;
         gap: 0.35rem;
       }
+
       .footer-brand-copy strong {
         font-size: 1.15rem;
         line-height: 1.1;
       }
+
       .footer-brand-copy p {
         margin: 0;
         font-size: 0.92rem;
-        color: var(--brand-text);
-        opacity: 0.8;
-        max-width: 540px;
+        color: var(--brand-neutral);
+        opacity: 0.85;
+        max-width: 640px;
       }
+
+      .footer-links {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 1.5rem;
+      }
+
+      .footer-link-group h4 {
+        margin: 0 0 0.75rem;
+        font-size: 0.95rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+
+      .footer-link-group ul {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      .footer-link-group a {
+        color: var(--brand-neutral);
+        text-decoration: none;
+        opacity: 0.85;
+      }
+
+      .footer-link-group a:hover {
+        opacity: 1;
+      }
+
       .footer-meta {
         display: flex;
         flex-wrap: wrap;
         gap: 1rem;
         font-size: 0.85rem;
-        color: var(--brand-text);
+        color: var(--brand-neutral);
         opacity: 0.75;
-        border-top: 1px solid currentColor;
+        border-top: 1px solid rgba(17, 24, 39, 0.15);
         padding-top: 1.5rem;
+      }
+
+      @media (max-width: 640px) {
+        .footer-brand {
+          flex-direction: column;
+          align-items: flex-start;
+        }
       }
     </style>
   </head>
@@ -163,15 +198,47 @@ const logoUrl = resolveAssetUrl(websiteData?.logo?.url);
       <div class="footer-inner">
         <div class="footer-brand">
           {logoUrl && (
-            <img src={logoUrl} alt={websiteData?.logo?.alternativeText || `${siteName} logo`} class="footer-logo" loading="lazy" />
+            <img src={logoUrl} alt={websiteData?.brand?.logo?.alternativeText || `${siteName} logo`} class="footer-logo" loading="lazy" />
           )}
           <div class="footer-brand-copy">
             <strong>{siteName}</strong>
-            <p>Travel stories and landing pages powered by Strapi. Use the CMS to tweak branding, copy, and asset delivery per market.</p>
+            {footer?.aboutText && <div set:html={footer.aboutText}></div>}
           </div>
         </div>
+
+        {footer?.linkGroups && footer.linkGroups.length > 0 && (
+          <div class="footer-links">
+            {footer.linkGroups.map(group => (
+              <div class="footer-link-group" key={group.id}>
+                {group.groupTitle && <h4>{group.groupTitle}</h4>}
+                {group.links && group.links.length > 0 && (
+                  <ul>
+                    {group.links.map(link => {
+                      const href = link.linkType === 'external_url'
+                        ? link.url || '#'
+                        : link.path || '#';
+
+                      return (
+                        <li key={link.id}>
+                          <a href={href} target={link.openInNewTab ? '_blank' : undefined} rel={link.openInNewTab ? 'noopener noreferrer' : undefined}>
+                            {link.label}
+                          </a>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+
         <div class="footer-meta">
-          <span>© {currentYear} {siteName}. All rights reserved.</span>
+          <span>
+            © {currentYear} {siteName}
+            {footer?.copyrightText ? `. ${footer?.copyrightText}` : ''}
+          </span>
+          {config.isDevelopment && <span>DEV MODE</span>}
         </div>
       </div>
     </footer>

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -2,7 +2,14 @@
 import Layout from '../../layouts/Layout.astro';
 import DebugPanel from '../../components/DebugPanel.astro';
 import LanguageSelector from '../../components/LanguageSelector.astro';
-import { getWebsiteData, getLocalizedWebsiteData, getArticles, getTags } from '../../services/cms';
+import {
+  getWebsiteData,
+  resolveCmsAssetUrl,
+  type Website,
+  type Article,
+  type Tag,
+  type NavMenuItem,
+} from '../../services/cms';
 import { isValidLanguage, getDefaultLanguage } from '../../utils/language';
 
 export async function getStaticPaths() {
@@ -10,708 +17,666 @@ export async function getStaticPaths() {
     const websiteData = await getWebsiteData();
 
     if (!websiteData) {
-      // Return default paths if CMS is unavailable
-      console.warn('Website data not available, using default locales');
+      console.warn('Website data not available, using default locale paths');
       return [
         { params: { lang: 'en' } },
-        { params: { lang: 'pt' } },
-        { params: { lang: 'es' } },
         { params: { lang: 'fr' } },
         { params: { lang: 'it' } },
+        { params: { lang: 'es' } },
+        { params: { lang: 'pt' } },
       ];
     }
 
-    // Generate paths for each available locale
-    return websiteData.locales.map(locale => ({
-      params: { lang: locale },
-    }));
+    const locales = websiteData.supportedLocales?.length
+      ? websiteData.supportedLocales
+      : websiteData.defaultLocale
+        ? [websiteData.defaultLocale]
+        : ['en'];
+
+    return locales.map(locale => ({ params: { lang: locale } }));
   } catch (error) {
     console.error('Error in getStaticPaths:', error);
-    // Return default paths as fallback
     return [
       { params: { lang: 'en' } },
-      { params: { lang: 'pt' } },
-      { params: { lang: 'es' } },
       { params: { lang: 'fr' } },
       { params: { lang: 'it' } },
+      { params: { lang: 'es' } },
+      { params: { lang: 'pt' } },
     ];
   }
 }
 
 const { lang } = Astro.params;
-let websiteData, articles, tags;
+let websiteData: Website | null = null;
+let articles: Article[] = [];
+let tags: Tag[] = [];
+let availableLocales: string[] = [];
+let targetLocale: string | undefined = typeof lang === 'string' ? lang : undefined;
 
 try {
-  websiteData = await getWebsiteData();
+  websiteData = await getWebsiteData(targetLocale);
 
-  // Validate language parameter
-  if (websiteData && lang && !isValidLanguage(lang, websiteData.locales)) {
-    return Astro.redirect(`/${getDefaultLanguage(websiteData.locales, websiteData.defaultLocale)}`);
+  if (!websiteData && targetLocale) {
+    websiteData = await getWebsiteData();
   }
 
-  // If no specific lang provided or invalid, use default
-  if (!lang) {
-    const defaultLang = websiteData?.defaultLocale || 'en';
-    return Astro.redirect(`/${defaultLang}`);
-  }
+  if (websiteData) {
+    const derivedLocales = [
+      ...(websiteData.supportedLocales || []),
+      websiteData.locale,
+      websiteData.defaultLocale,
+      ...(websiteData.localizations?.map(localization => localization.locale) || []),
+    ].filter((entry): entry is string => Boolean(entry));
 
-  articles = await getArticles(lang);
-  tags = await getTags(lang);
+    availableLocales = Array.from(new Set(derivedLocales));
+
+    if (availableLocales.length === 0) {
+      availableLocales = ['en'];
+    }
+
+    if (targetLocale && !isValidLanguage(targetLocale, availableLocales)) {
+      return Astro.redirect(`/${getDefaultLanguage(availableLocales, websiteData.defaultLocale)}`);
+    }
+
+    targetLocale = targetLocale || websiteData.locale || websiteData.defaultLocale || availableLocales[0];
+
+    const localizedArticles = (websiteData.articles || []).filter(article => {
+      if (!targetLocale || !article.locale) {
+        return true;
+      }
+
+      return article.locale === targetLocale;
+    });
+
+    articles = localizedArticles
+      .slice()
+      .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+
+    const localizedTags = (websiteData.tags || []).filter(tag => {
+      if (!targetLocale || !tag.locale) {
+        return true;
+      }
+
+      return tag.locale === targetLocale;
+    });
+
+    tags = localizedTags.slice().sort((a, b) => a.name.localeCompare(b.name));
+  } else {
+    console.warn('Website data unavailable, site will render with fallback copy.');
+    availableLocales = ['en'];
+    targetLocale = targetLocale || 'en';
+  }
 } catch (error) {
   console.error('Error loading page data:', error);
-  // Set defaults for offline/error mode
   websiteData = null;
   articles = [];
   tags = [];
+  availableLocales = ['en'];
+  targetLocale = targetLocale || 'en';
 }
 
-// Use brand colors from CMS with sensible defaults
-const brandColors = websiteData?.brandColors?.[0] || {
-  primary: '#FF6B35',
-  secondary: '#F8FAFC',
-  background: '#FFFFFF',
-  text: '#2D3748'
+const palette = {
+  primary: websiteData?.theme?.palette?.primary || websiteData?.theme?.brandColor || '#FF8A00',
+  secondary: websiteData?.theme?.palette?.secondary || '#0EA5B5',
+  accent: websiteData?.theme?.palette?.accent || '#FFD141',
+  background: websiteData?.theme?.palette?.background || '#FFFFFF',
+  surface: websiteData?.theme?.palette?.surface || '#F6F7F9',
+  text: websiteData?.theme?.palette?.neutral || '#111827',
+  muted: websiteData?.theme?.palette?.muted || '#94A3B8',
 };
 
-const summaryFallback = 'Full story preview coming soon. Check back shortly for the highlights.';
+const summaryFallback =
+  websiteData?.seoDefaults?.metaDescription ||
+  websiteData?.seoDefaults?.metaTitle ||
+  websiteData?.name ||
+  '';
+const readMoreLabel = websiteData?.systemLabels?.readMoreLabel || null;
+const searchPlaceholder = websiteData?.systemLabels?.searchPlaceholder || null;
+const backToHomeLabel =
+  websiteData?.systemLabels?.backToHomeLabel ||
+  websiteData?.header?.brandDisplayName ||
+  websiteData?.name ||
+  null;
+const heroImageUrl = resolveCmsAssetUrl(websiteData?.homepageHero?.image);
+const navItems = (websiteData?.header?.primaryNav || []).filter(item => Boolean(item?.label));
+const siteTitle = websiteData?.seoDefaults?.metaTitle || websiteData?.name || websiteData?.header?.brandDisplayName || 'Home';
+const resolvedLocale = targetLocale || availableLocales[0] || websiteData?.defaultLocale || 'en';
+
+function formatDate(value?: string): string {
+  if (!value) return '';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toLocaleDateString(resolvedLocale, { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+function resolveNavHref(item: NavMenuItem): string {
+  if (item.linkType === 'external_url') {
+    return item.url || '#';
+  }
+
+  const localeSegment = resolvedLocale;
+  if (!item.path) {
+    return `/${localeSegment}`;
+  }
+
+  if (item.path.startsWith('http')) {
+    return item.path;
+  }
+
+  const normalizedPath = item.path.startsWith('/') ? item.path : `/${item.path}`;
+  return `/${localeSegment}${normalizedPath === '/' ? '' : normalizedPath}`;
+}
+
+function resolveArticleUrl(article: Article): string {
+  const localeSegment = resolvedLocale;
+  return `/${localeSegment}/articles/${article.slug}`;
+}
+
+const currentPath = Astro.url.pathname;
+
+function deriveArticleSummary(article: Article): string {
+  if (article.summary) {
+    return article.summary;
+  }
+
+  if (article.body) {
+    const stripped = article.body
+      .replace(/```[\s\S]*?```/g, '')
+      .replace(/`([^`]*)`/g, '$1')
+      .replace(/\[(.*?)\]\((.*?)\)/g, '$1')
+      .replace(/[>#*_~]/g, ' ')
+      .replace(/\r?\n+/g, ' ');
+
+    const condensed = stripped.replace(/\s+/g, ' ').trim();
+
+    if (condensed) {
+      const words = condensed.split(' ');
+      const excerpt = words.slice(0, 40).join(' ');
+      return words.length > 40 ? `${excerpt}…` : excerpt;
+    }
+  }
+
+  return summaryFallback;
+}
 ---
 
-<Layout title="Home" websiteData={websiteData}>
-
-	<style define:vars={{
-		primary: brandColors.primary,
-		secondary: brandColors.secondary,
-		background: brandColors.background,
-		text: brandColors.text
-	}}>
-		/* Wanderlust-inspired styles - CMS driven */
-		:root {
-			--orange: #FF6B35;
-			--blue: #4A90E2;
-			--surface: #f9fafb;
-			--border-radius: 8px;
-			--text-secondary: #6b7280;
-		}
-
-		body {
-			margin: 0;
-			padding: 0;
-			font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
-			background: var(--background);
-			color: var(--text);
-		}
-
-		/* Navigation Header */
-		.navbar {
-			background: white;
-			border-bottom: 1px solid #e5e7eb;
-			padding: 1rem 2rem;
-			display: flex;
-			justify-content: space-between;
-			align-items: center;
-			width: 100%;
-			box-sizing: border-box;
-		}
-
-		.navbar-brand {
-			display: flex;
-			align-items: center;
-			gap: 0.5rem;
-			font-size: 1.5rem;
-			font-weight: 700;
-			color: var(--orange);
-			text-decoration: none;
-		}
-
-		.navbar-nav {
-			display: flex;
-			gap: 2rem;
-			list-style: none;
-			margin: 0;
-			padding: 0;
-		}
-
-		.navbar-nav a {
-			color: #4b5563;
-			text-decoration: none;
-			font-weight: 500;
-			transition: color 0.2s;
-		}
-
-		.navbar-nav a:hover {
-			color: var(--orange);
-		}
-
-		.navbar-actions {
-			display: flex;
-			align-items: center;
-			gap: 1rem;
-		}
-
-		.btn-subscribe {
-			background: transparent;
-			color: #4b5563;
-			border: none;
-			cursor: pointer;
-			font-weight: 500;
-		}
-
-		.btn-start {
-			background: var(--orange);
-			color: white;
-			padding: 0.5rem 1.5rem;
-			border: none;
-			border-radius: 6px;
-			cursor: pointer;
-			font-weight: 500;
-			transition: transform 0.2s;
-		}
-
-		.btn-start:hover {
-			transform: translateY(-1px);
-		}
-
-		/* Hero Section */
-		.hero {
-			background: linear-gradient(135deg, rgba(255, 107, 53, 0.9), rgba(74, 144, 226, 0.8));
-			min-height: 60vh;
-			display: flex;
-			align-items: center;
-			justify-content: center;
-			text-align: center;
-			color: white;
-			position: relative;
-			width: 100%;
-			box-sizing: border-box;
-		}
-
-		.hero-content {
-			max-width: 600px;
-			padding: 2rem;
-		}
-
-		.hero h1 {
-			font-size: clamp(2.5rem, 5vw, 4rem);
-			font-weight: 700;
-			margin-bottom: 1.5rem;
-			line-height: 1.2;
-		}
-
-		.hero p {
-			font-size: 1.25rem;
-			margin-bottom: 2rem;
-			opacity: 0.9;
-			line-height: 1.6;
-		}
-
-		.hero-buttons {
-			display: flex;
-			gap: 1rem;
-			justify-content: center;
-			flex-wrap: wrap;
-		}
-
-		.btn-hero {
-			padding: 0.875rem 2rem;
-			border-radius: 8px;
-			font-weight: 600;
-			text-decoration: none;
-			transition: all 0.3s;
-			display: inline-flex;
-			align-items: center;
-			gap: 0.5rem;
-		}
-
-		.btn-primary {
-			background: var(--orange);
-			color: white;
-		}
-
-		.btn-secondary {
-			background: rgba(255, 255, 255, 0.2);
-			color: white;
-			border: 2px solid rgba(255, 255, 255, 0.3);
-			backdrop-filter: blur(10px);
-		}
-
-		.btn-hero:hover {
-			transform: translateY(-2px);
-			box-shadow: 0 8px 25px rgba(0,0,0,0.2);
-		}
-
-		/* Main Content */
-		.container {
-			max-width: 1200px;
-			margin: 0 auto;
-			padding: 0 2rem;
-		}
-
-		.section {
-			padding: 4rem 0;
-		}
-
-		.section-title {
-			font-size: 2.5rem;
-			font-weight: 700;
-			text-align: center;
-			margin-bottom: 1rem;
-			color: #1f2937;
-		}
-
-		.section-subtitle {
-			font-size: 1.125rem;
-			color: #6b7280;
-			text-align: center;
-			max-width: 600px;
-			margin: 0 auto 3rem;
-			line-height: 1.6;
-		}
-
-		/* Article Grid */
-		.articles-grid {
-			display: grid;
-			grid-template-columns: 2fr 1fr;
-			gap: 2rem;
-			margin-top: 2rem;
-		}
-
-		.article-card {
-			background: white;
-			border-radius: 12px;
-			overflow: hidden;
-			box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
-			transition: transform 0.3s, box-shadow 0.3s;
-			position: relative;
-			display: flex;
-			flex-direction: column;
-			height: auto;
-		}
-
-		.article-card:hover {
-			transform: translateY(-8px);
-			box-shadow: 0 20px 40px rgba(0, 0, 0, 0.15);
-		}
-
-		.article-image {
-			width: 100%;
-			height: 240px;
-			object-fit: cover;
-			transition: transform 0.3s;
-		}
-
-		.article-card:hover .article-image {
-			transform: scale(1.05);
-		}
-
-		.article-content {
-			padding: 1.5rem;
-			display: flex;
-			flex-direction: column;
-			gap: 0.75rem;
-			flex: 1;
-		}
-
-		.article-meta {
-			display: flex;
-			align-items: center;
-			gap: 1rem;
-			margin-bottom: 1rem;
-			font-size: 0.875rem;
-			color: #6b7280;
-			flex-wrap: wrap;
-		}
-
-			.article-title {
-				font-size: 1.65rem;
-				font-weight: 600;
-				margin-bottom: 1rem;
-				line-height: 1.4;
-				display: -webkit-box;
-			-webkit-box-orient: vertical;
-			-webkit-line-clamp: 3;
-			overflow: hidden;
-		}
-
-		.article-title a {
-			color: #1f2937;
-			text-decoration: none;
-			transition: color 0.2s;
-			display: block;
-		}
-
-		.article-title a:hover {
-			color: var(--orange);
-		}
-
-		.article-summary {
-			color: #6b7280;
-			line-height: 1.6;
-			margin-bottom: 1rem;
-			display: -webkit-box;
-			-webkit-box-orient: vertical;
-			-webkit-line-clamp: 3;
-			overflow: hidden;
-			min-height: calc(1.6em * 3);
-		}
-
-		.article-summary.placeholder {
-			opacity: 0.7;
-			font-style: italic;
-		}
-
-		.read-more {
-			color: var(--orange);
-			font-weight: 500;
-			text-decoration: none;
-			display: inline-flex;
-			align-items: center;
-			gap: 0.5rem;
-			transition: gap 0.2s;
-			margin-top: auto;
-		}
-
-		.read-more:hover {
-			gap: 0.75rem;
-		}
-
-		/* Right column for smaller articles */
-		.articles-right-column {
-			display: flex;
-			flex-direction: column;
-			gap: 2rem;
-		}
-
-		/* Large feature card */
-			.article-card.featured {
-				min-height: 500px;
-			}
-
-			.article-card.featured .article-image {
-				height: 300px;
-			}
-
-			.article-card.featured .article-title {
-				font-size: 2rem;
-				line-height: 1.2;
-				margin-bottom: 0.75rem;
-			}
-
-		.article-card.featured .article-summary {
-			font-size: 1.05rem;
-			-webkit-line-clamp: 3;
-			min-height: calc(1.6em * 3);
-		}
-
-		/* Smaller article cards in right column */
-		.article-card.small {
-			height: auto;
-			min-height: 240px;
-		}
-
-		.article-card.small .article-image {
-			height: 140px;
-		}
-
-			.article-card.small .article-title {
-				font-size: 1.2rem;
-				margin-bottom: 0.35rem;
-				-webkit-line-clamp: 2;
-			}
-
-		.article-card.small .article-meta {
-			font-size: 0.75rem;
-			margin-bottom: 0.75rem;
-		}
-
-		.article-card.small .article-summary {
-			-webkit-line-clamp: 2;
-			font-size: 0.95rem;
-			margin-bottom: 0.75rem;
-			line-height: 1.5;
-			min-height: calc(1.5em * 2);
-		}
-
-		.article-card.small .article-content {
-			padding: 1rem;
-		}
-
-		/* Row of 3 articles */
-		.articles-row-three {
-			display: grid;
-			grid-template-columns: repeat(3, 1fr);
-			gap: 2rem;
-			margin-top: 3rem;
-		}
-
-			.article-card.medium {
-				height: auto;
-				min-height: 350px;
-			}
-
-			.article-card.medium .article-image {
-				height: 200px;
-			}
-
-			.article-card.medium .article-title {
-				font-size: 1.4rem;
-				-webkit-line-clamp: 2;
-			}
-
-		.article-card.medium .article-summary {
-			font-size: 1rem;
-			-webkit-line-clamp: 3;
-			min-height: calc(1.6em * 3);
-		}
-
-			/* Responsive */
-		@media (max-width: 768px) {
-			.navbar {
-				padding: 1rem;
-			}
-
-			.navbar-nav {
-				display: none;
-			}
-
-			.hero {
-				min-height: 50vh;
-			}
-
-			.hero-buttons {
-				flex-direction: column;
-				align-items: center;
-			}
-
-			.btn-hero {
-				width: 100%;
-				max-width: 280px;
-				justify-content: center;
-			}
-
-			.articles-grid {
-				grid-template-columns: 1fr;
-			}
-
-			.articles-row-three {
-				grid-template-columns: 1fr;
-			}
-
-			.article-card.featured {
-				height: auto;
-			}
-
-			.article-card.medium {
-				height: auto;
-			}
-
-			.container {
-				padding: 0 1rem;
-			}
-		}
-	</style>
-
-	{websiteData ? (
-		<>
-			<!-- Navigation Header -->
-			<nav class="navbar">
-				<a href="/" class="navbar-brand">
-					{websiteData.logo && (
-						<img
-							src={websiteData.logo.url.startsWith('http') ? websiteData.logo.url : `http://localhost:1337${websiteData.logo.url}`}
-							alt={websiteData.logo.alternativeText || 'Logo'}
-							style="height: 24px;"
-						/>
-					)}
-					{websiteData.name}
-				</a>
-
-				<ul class="navbar-nav">
-					<li><a href="/">All Stories</a></li>
-					{tags.slice(0, 5).map(tag => (
-						<li><a href={`/tag/${tag.slug}`}>{tag.name}</a></li>
-					))}
-				</ul>
-
-				<div class="navbar-actions">
-					{websiteData?.locales && (
-						<LanguageSelector
-							availableLocales={websiteData.locales}
-							currentLang={lang}
-							currentPath={Astro.url.pathname}
-						/>
-					)}
-				</div>
-			</nav>
-
-			<!-- Hero Section -->
-			<section class="hero">
-				<div class="hero-content">
-					<h1>Discover Your Next<br>Adventure</h1>
-					<p>Expert travel guides, hidden gems, and insider tips to make your journey unforgettable. From European cobblestone streets to tropical paradises.</p>
-					<div class="hero-buttons">
-						<a href="#articles" class="btn-hero btn-primary">
-							Explore Destinations
-							<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-								<path d="m9 18 6-6-6-6"/>
-							</svg>
-						</a>
-					</div>
-				</div>
-			</section>
-
-			<!-- Main Content -->
-			<div class="container">
-
-
-				<!-- Articles Section -->
-				<section class="section" id="articles">
-					<h2 class="section-title">Latest Travel Stories</h2>
-					<p class="section-subtitle">Inspiring destinations, expert tips, and unforgettable experiences from around the world</p>
-
-					{articles.length > 0 ? (
-						<div class="articles-grid">
-						<!-- Featured article on the left -->
-							{articles[0] && (
-								<article class="article-card featured">
-									<img
-										src={articles[0].coverImage ?
-											(articles[0].coverImage.url.startsWith('http') ? articles[0].coverImage.url : `http://localhost:1337${articles[0].coverImage.url}`) :
-											'/images/placeholder.jpg'
-										}
-										alt={articles[0].coverImage?.alternativeText || articles[0].title}
-										class="article-image"
-									/>
-									<div class="article-content">
-										<div class="article-meta">
-											<span>📅 {new Date(articles[0].updatedAt).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}</span>
-											{articles[0].readingTime && <span>⏱ {articles[0].readingTime} min read</span>}
-											{articles[0].tags?.[0] && <span>🏷️ {articles[0].tags[0].name}</span>}
-										</div>
-										<h3 class="article-title">
-											<a href={`/articles/${articles[0].slug}`}>{articles[0].title}</a>
-										</h3>
-										<p class={`article-summary${articles[0].summary ? '' : ' placeholder'}`}>
-											{articles[0].summary || summaryFallback}
-										</p>
-										<a href={`/articles/${articles[0].slug}`} class="read-more">
-											Read More
-											<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-												<path d="m9 18 6-6-6-6"/>
-											</svg>
-										</a>
-									</div>
-								</article>
-							)}
-
-						<!-- Right column with two smaller articles -->
-							<div class="articles-right-column">
-								{articles.slice(1, 3).map((article) => (
-									<article class="article-card small">
-										<img
-											src={article.coverImage ?
-												(article.coverImage.url.startsWith('http') ? article.coverImage.url : `http://localhost:1337${article.coverImage.url}`) :
-												'/images/placeholder.jpg'
-											}
-											alt={article.coverImage?.alternativeText || article.title}
-											class="article-image"
-										/>
-										<div class="article-content">
-											<div class="article-meta">
-												<span>📅 {new Date(article.updatedAt).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}</span>
-												{article.readingTime && <span>⏱ {article.readingTime} min read</span>}
-												{article.tags?.[0] && <span>🏷️ {article.tags[0].name}</span>}
-											</div>
-											<h3 class="article-title">
-												<a href={`/articles/${article.slug}`}>{article.title}</a>
-											</h3>
-											<p class={`article-summary${article.summary ? '' : ' placeholder'}`}>
-												{article.summary || summaryFallback}
-											</p>
-											<a href={`/articles/${article.slug}`} class="read-more">
-												Read More
-												<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-													<path d="m9 18 6-6-6-6"/>
-												</svg>
-											</a>
-										</div>
-									</article>
-								))}
-							</div>
-						</div>
-
-						<!-- Row of 3 articles -->
-						{articles.length > 3 && (
-							<div class="articles-row-three">
-								{articles.slice(3, 6).map((article) => (
-									<article class="article-card medium">
-										<img
-											src={article.coverImage ?
-												(article.coverImage.url.startsWith('http') ? article.coverImage.url : `http://localhost:1337${article.coverImage.url}`) :
-												'/images/placeholder.jpg'
-											}
-											alt={article.coverImage?.alternativeText || article.title}
-											class="article-image"
-										/>
-										<div class="article-content">
-											<div class="article-meta">
-												<span>📅 {new Date(article.updatedAt).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}</span>
-												{article.readingTime && <span>⏱ {article.readingTime} min read</span>}
-												{article.tags?.[0] && <span>🏷️ {article.tags[0].name}</span>}
-											</div>
-											<h3 class="article-title">
-												<a href={`/articles/${article.slug}`}>{article.title}</a>
-											</h3>
-											<p class={`article-summary${article.summary ? '' : ' placeholder'}`}>
-												{article.summary || summaryFallback}
-											</p>
-											<a href={`/articles/${article.slug}`} class="read-more">
-												Read More
-												<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-													<path d="m9 18 6-6-6-6"/>
-												</svg>
-											</a>
-										</div>
-									</article>
-								))}
-							</div>
-						)}
-					) : (
-						<div style="text-align: center; padding: 3rem; color: #6b7280;">
-							<h3>No stories yet</h3>
-							<p>Check back soon for amazing travel stories and guides!</p>
-						</div>
-					)}
-				</section>
-			</div>
-		</>
-	) : (
-		<!-- Fallback for no website data -->
-		<div class="container" style="text-align: center; padding: 5rem 2rem;">
-			<svg width="80" height="80" viewBox="0 0 24 24" fill="none" stroke="var(--orange)" stroke-width="1.5" style="margin-bottom: 2rem;">
-				<path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/>
-				<line x1="12" y1="9" x2="12" y2="13"/>
-				<line x1="12" y1="17" x2="12.01" y2="17"/>
-			</svg>
-			<h1 style="color: var(--text); margin-bottom: 1rem;">Welcome to Astro</h1>
-			<div style="background: var(--surface); padding: 2rem; border-radius: var(--border-radius); border-left: 4px solid var(--orange); max-width: 600px; margin: 0 auto;">
-				<h3 style="color: var(--orange); margin-bottom: 0.5rem;">Configuration Required</h3>
-				<p style="color: var(--text-secondary); line-height: 1.6;">
-					Unable to load website data from CMS. Please check your environment variables and ensure your CMS is properly configured.
-				</p>
-			</div>
-		</div>
-	)}
-
-	<DebugPanel
-		websiteData={websiteData}
-		articles={articles}
-		additionalInfo={{
-			"Current Language": lang,
-			"Tags": tags.length,
-			"Tag Names": tags.map(t => t.name).join(", "),
-			"Logo": websiteData?.logo ? "Available" : "Not set",
-			"Favicon": websiteData?.favicon ? "Available" : "Not set",
-			"Brand Colors": websiteData?.brandColors?.length || 0
-		}}
-	/>
+<Layout title={siteTitle} websiteData={websiteData}>
+  <style define:vars={{
+    primary: palette.primary,
+    secondary: palette.secondary,
+    accent: palette.accent,
+    background: palette.background,
+    surface: palette.surface,
+    text: palette.text,
+    muted: palette.muted,
+  }}>
+    :root {
+      --transition-normal: 0.25s ease;
+    }
+
+    body {
+      background: var(--background);
+      color: var(--text);
+    }
+
+    .site-shell {
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .site-header {
+      position: sticky;
+      top: 0;
+      z-index: 20;
+      background: rgba(255, 255, 255, 0.92);
+      backdrop-filter: blur(12px);
+      border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+    }
+
+    .header-inner {
+      max-width: 1200px;
+      margin: 0 auto;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1.5rem;
+      padding: 1.1rem 1.75rem;
+    }
+
+    .brand-link {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      text-decoration: none;
+      color: inherit;
+    }
+
+    .brand-copy {
+      display: flex;
+      flex-direction: column;
+      gap: 0.2rem;
+    }
+
+    .brand-name {
+      font-weight: 700;
+      font-size: 1.1rem;
+      margin: 0;
+    }
+
+    .brand-tagline {
+      font-size: 0.8rem;
+      color: var(--muted);
+      margin: 0;
+    }
+
+    nav.primary-nav {
+      display: flex;
+      gap: 1rem;
+      align-items: center;
+      flex: 1;
+    }
+
+    nav.primary-nav a {
+      text-decoration: none;
+      color: var(--text);
+      font-weight: 500;
+      font-size: 0.95rem;
+      padding: 0.35rem 0.5rem;
+      border-radius: 6px;
+      transition: background var(--transition-normal), color var(--transition-normal);
+    }
+
+    nav.primary-nav a:hover {
+      background: rgba(15, 23, 42, 0.05);
+      color: var(--primary);
+    }
+
+    .hero {
+      position: relative;
+      background: linear-gradient(120deg, rgba(255, 138, 0, 0.85), rgba(14, 165, 181, 0.7));
+      color: white;
+      padding: 6rem 1.75rem 5rem;
+      text-align: center;
+      overflow: hidden;
+    }
+
+    .hero::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background-image: var(--hero-image, none);
+      background-size: cover;
+      background-position: center;
+      opacity: 0.35;
+      z-index: 0;
+      transform: scale(1.05);
+    }
+
+    .hero-content {
+      position: relative;
+      max-width: 760px;
+      margin: 0 auto;
+      z-index: 1;
+      display: grid;
+      gap: 1.25rem;
+    }
+
+    .hero h1 {
+      font-size: clamp(2.75rem, 5vw, 3.8rem);
+      margin: 0;
+      letter-spacing: -0.02em;
+    }
+
+    .hero p {
+      margin: 0;
+      font-size: 1.1rem;
+      line-height: 1.7;
+      color: rgba(255, 255, 255, 0.92);
+    }
+
+    .hero-actions {
+      display: flex;
+      justify-content: center;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+
+    .hero-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.8rem 1.6rem;
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.2);
+      color: white;
+      text-decoration: none;
+      font-weight: 600;
+      border: 1px solid rgba(255, 255, 255, 0.4);
+      transition: transform var(--transition-normal), box-shadow var(--transition-normal);
+    }
+
+    .hero-link:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 12px 30px rgba(15, 23, 42, 0.25);
+    }
+
+    .content-section {
+      padding: 3.5rem 1.5rem 4rem;
+    }
+
+    .container {
+      max-width: 1200px;
+      margin: 0 auto;
+      display: grid;
+      gap: 2.5rem;
+    }
+
+    .section-heading {
+      display: grid;
+      gap: 1rem;
+      text-align: center;
+      max-width: 760px;
+      margin: 0 auto;
+    }
+
+    .section-heading h2 {
+      margin: 0;
+      font-size: 2.25rem;
+      letter-spacing: -0.015em;
+    }
+
+    .section-heading p {
+      margin: 0;
+      color: var(--muted);
+      line-height: 1.6;
+      font-size: 1.05rem;
+    }
+
+    .section-toolbar {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem;
+      justify-content: center;
+      align-items: center;
+    }
+
+    .search-input {
+      padding: 0.75rem 1rem;
+      min-width: 240px;
+      border-radius: 999px;
+      border: 1px solid rgba(148, 163, 184, 0.4);
+      background: white;
+      color: var(--text);
+      font-size: 0.95rem;
+    }
+
+    .search-input:disabled {
+      opacity: 0.65;
+      cursor: not-allowed;
+    }
+
+    .tag-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+    }
+
+    .tag {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.3rem;
+      padding: 0.45rem 0.9rem;
+      border-radius: 999px;
+      background: rgba(255, 138, 0, 0.12);
+      color: var(--primary);
+      font-size: 0.82rem;
+      font-weight: 600;
+    }
+
+    .articles-grid {
+      display: grid;
+      gap: 2rem;
+    }
+
+    .article-card {
+      display: grid;
+      gap: 1.25rem;
+      border-radius: 20px;
+      overflow: hidden;
+      background: var(--surface);
+      box-shadow: 0 18px 35px rgba(15, 23, 42, 0.08);
+      transition: transform var(--transition-normal), box-shadow var(--transition-normal);
+    }
+
+    .article-card:hover {
+      transform: translateY(-6px);
+      box-shadow: 0 22px 40px rgba(15, 23, 42, 0.12);
+    }
+
+    .article-media {
+      position: relative;
+      padding-top: 52%;
+      overflow: hidden;
+    }
+
+    .article-media img {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      transition: transform var(--transition-normal);
+    }
+
+    .article-card:hover .article-media img {
+      transform: scale(1.04);
+    }
+
+    .article-body {
+      padding: 0 1.8rem 1.8rem;
+      display: grid;
+      gap: 0.75rem;
+    }
+
+    .article-meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem;
+      font-size: 0.85rem;
+      color: var(--muted);
+    }
+
+    .article-title {
+      margin: 0;
+      font-size: 1.6rem;
+      letter-spacing: -0.01em;
+    }
+
+    .article-title a {
+      text-decoration: none;
+      color: inherit;
+    }
+
+    .article-summary {
+      margin: 0;
+      color: var(--muted);
+      line-height: 1.6;
+      font-size: 1rem;
+    }
+
+    .read-more {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-weight: 600;
+      color: var(--primary);
+      text-decoration: none;
+      margin-top: 0.5rem;
+      transition: gap var(--transition-normal);
+    }
+
+    .read-more:hover {
+      gap: 0.75rem;
+    }
+
+    .empty-state {
+      text-align: center;
+      padding: 3rem 2rem;
+      border-radius: 16px;
+      background: var(--surface);
+      color: var(--muted);
+    }
+
+    @media (max-width: 900px) {
+      nav.primary-nav {
+        display: none;
+      }
+
+      .header-inner {
+        padding: 1rem;
+      }
+    }
+
+    @media (max-width: 720px) {
+      .hero {
+        padding: 4.5rem 1.5rem 3.5rem;
+      }
+
+      .article-body {
+        padding: 0 1.2rem 1.5rem;
+      }
+    }
+  </style>
+
+  {websiteData ? (
+    <div class="site-shell">
+      <header class="site-header">
+        <div class="header-inner">
+          <a class="brand-link" href={`/${resolvedLocale}`}>
+            <div class="brand-copy">
+              <span class="brand-name">{websiteData.header?.brandDisplayName || websiteData.name}</span>
+              {websiteData.header?.tagline && <span class="brand-tagline">{websiteData.header.tagline}</span>}
+            </div>
+          </a>
+          {navItems.length > 0 && (
+            <nav class="primary-nav">
+              {navItems.map(item => (
+                <a
+                  key={item.id}
+                  href={resolveNavHref(item)}
+                  target={item.openInNewTab ? '_blank' : undefined}
+                  rel={item.openInNewTab ? 'noopener noreferrer' : undefined}
+                >
+                  {item.label}
+                </a>
+              ))}
+            </nav>
+          )}
+          <LanguageSelector availableLocales={availableLocales} currentLang={resolvedLocale} currentPath={currentPath} />
+        </div>
+      </header>
+
+      <section class="hero" style={heroImageUrl ? `--hero-image: url('${heroImageUrl}')` : undefined}>
+        <div class="hero-content">
+          <h1>{websiteData.name}</h1>
+          {websiteData.header?.tagline && <p>{websiteData.header.tagline}</p>}
+          {!websiteData.header?.tagline && websiteData.seoDefaults?.metaDescription && <p>{websiteData.seoDefaults.metaDescription}</p>}
+          <div class="hero-actions">
+            {backToHomeLabel && (
+              <a class="hero-link" href={`/${resolvedLocale}`}>
+                {backToHomeLabel}
+                <span aria-hidden="true">→</span>
+              </a>
+            )}
+            {navItems[0] && navItems[0].linkType !== 'external_url' && navItems[0].path && navItems[0].label && (
+              <a class="hero-link" href={resolveNavHref(navItems[0])}>
+                {navItems[0].label}
+                <span aria-hidden="true">→</span>
+              </a>
+            )}
+          </div>
+        </div>
+      </section>
+
+      <section class="content-section">
+        <div class="container">
+          <div class="section-heading">
+            <h2>{websiteData.header?.brandDisplayName || websiteData.name}</h2>
+            {websiteData.seoDefaults?.metaDescription && <p>{websiteData.seoDefaults.metaDescription}</p>}
+          </div>
+
+          <div class="section-toolbar">
+            {searchPlaceholder && (
+              <input class="search-input" type="search" placeholder={searchPlaceholder} disabled />
+            )}
+            {tags.length > 0 && (
+              <div class="tag-list">
+                {tags.map(tag => (
+                  <span class="tag" key={tag.id}>#{tag.name}</span>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {articles.length > 0 ? (
+            <div class="articles-grid">
+              {articles.map(article => {
+                const coverUrl = resolveCmsAssetUrl(article.coverImage) || heroImageUrl || '/images/placeholder.jpg';
+
+                return (
+                  <article class="article-card" key={article.id}>
+                    <div class="article-media">
+                      <img src={coverUrl} alt={article.coverImage?.alternativeText || article.title} loading="lazy" />
+                    </div>
+                    <div class="article-body">
+                      <div class="article-meta">
+                        {article.updatedAt && <span>{formatDate(article.updatedAt)}</span>}
+                        {article.readingTime && <span>{article.readingTime} min</span>}
+                        {article.tags?.[0] && <span>#{article.tags[0].name}</span>}
+                      </div>
+                      <h3 class="article-title">
+                        <a href={resolveArticleUrl(article)}>{article.title}</a>
+                      </h3>
+                      <p class="article-summary">{deriveArticleSummary(article) || summaryFallback}</p>
+                      {readMoreLabel && (
+                        <a class="read-more" href={resolveArticleUrl(article)}>
+                          {readMoreLabel}
+                          <span aria-hidden="true">→</span>
+                        </a>
+                      )}
+                    </div>
+                  </article>
+                );
+              })}
+            </div>
+          ) : (
+            <div class="empty-state">
+              <h3>{websiteData.header?.brandDisplayName || websiteData.name || siteTitle}</h3>
+              {summaryFallback && <p>{summaryFallback}</p>}
+            </div>
+          )}
+        </div>
+      </section>
+    </div>
+  ) : (
+    <div class="content-section">
+      <div class="container" style="max-width: 720px; text-align: center;">
+        <h1>CMS configuration required</h1>
+        <p>We could not load website settings from Strapi. Verify your environment variables and API permissions.</p>
+      </div>
+    </div>
+  )}
+
+  <DebugPanel
+    websiteData={websiteData}
+    articles={articles}
+    additionalInfo={{
+      'Current Language': resolvedLocale,
+      'Tags': tags.length,
+      'Available Locales': availableLocales.join(', '),
+      'Hero Image': heroImageUrl ? 'Configured' : 'Not set',
+      'Theme Primary': palette.primary,
+    }}
+  />
 </Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,10 +5,14 @@ import { getDefaultLanguage } from '../utils/language';
 const websiteData = await getWebsiteData();
 
 if (websiteData) {
-  const defaultLang = getDefaultLanguage(websiteData.locales, websiteData.defaultLocale);
+  const locales = websiteData.supportedLocales?.length
+    ? websiteData.supportedLocales
+    : websiteData.defaultLocale
+      ? [websiteData.defaultLocale]
+      : [];
+  const defaultLang = getDefaultLanguage(locales, websiteData.defaultLocale);
   return Astro.redirect(`/${defaultLang}`);
 }
 
-// If no website data, redirect to English as fallback
 return Astro.redirect('/en');
 ---

--- a/src/services/cms.ts
+++ b/src/services/cms.ts
@@ -10,7 +10,6 @@ interface HttpRequest {
   error?: string;
 }
 
-// Global request tracker for development
 const httpRequests: HttpRequest[] = [];
 
 export function getHttpRequests(): HttpRequest[] {
@@ -43,14 +42,13 @@ async function trackHttpRequest<T>(url: string, requestInit: RequestInit): Promi
     request.response = data;
 
     if (config.isDevelopment) {
-      httpRequests.unshift(request); // Add to beginning
-      // Keep only last 20 requests
+      httpRequests.unshift(request);
       if (httpRequests.length > 20) {
         httpRequests.length = 20;
       }
     }
 
-    return data;
+    return data as T;
   } catch (error) {
     const endTime = Date.now();
     request.duration = endTime - startTime;
@@ -67,90 +65,179 @@ async function trackHttpRequest<T>(url: string, requestInit: RequestInit): Promi
   }
 }
 
-interface ColorPalette {
-  primary: string;
-  secondary: string;
-  background: string;
-  text?: string;
+function buildCmsHeaders(): HeadersInit {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+
+  if (config.cmsApiToken) {
+    headers.Authorization = `Bearer ${config.cmsApiToken}`;
+  }
+
+  return headers;
 }
 
-interface SEOMeta {
-  metaTitle?: string;
-  metaDescription?: string;
+export interface Media {
+  id: number;
+  url: string;
+  alternativeText?: string | null;
+  caption?: string | null;
+  width?: number | null;
+  height?: number | null;
+  formats?: Record<string, { url: string }> | null;
 }
 
-interface Website {
+export interface SEODefaults {
+  id: number;
+  metaTitle?: string | null;
+  metaDescription?: string | null;
+}
+
+export interface ThemePaletteSet {
+  id?: number;
+  primary?: string | null;
+  secondary?: string | null;
+  accent?: string | null;
+  background?: string | null;
+  surface?: string | null;
+  muted?: string | null;
+  neutral?: string | null;
+}
+
+export interface ThemePalette {
+  id: number;
+  brandColor?: string | null;
+  palette?: ThemePaletteSet | null;
+}
+
+export interface BrandIdentity {
+  id: number;
+  logo?: Media | null;
+  favicon?: Media | null;
+}
+
+export type LinkType = 'internal_route' | 'external_url';
+
+export interface NavMenuItem {
+  id: number;
+  label: string;
+  linkType: LinkType;
+  path?: string | null;
+  url?: string | null;
+  openInNewTab?: boolean | null;
+}
+
+export interface NavLinkGroup {
+  id: number;
+  groupTitle?: string | null;
+  links?: NavMenuItem[];
+}
+
+export interface UIHeader {
+  id: number;
+  brandDisplayName?: string | null;
+  tagline?: string | null;
+  primaryNav?: NavMenuItem[];
+}
+
+export interface UIFooter {
+  id: number;
+  aboutText?: string | null;
+  linkGroups?: NavLinkGroup[];
+  copyrightText?: string | null;
+}
+
+export interface UISystemLabels {
+  id: number;
+  searchPlaceholder?: string | null;
+  readMoreLabel?: string | null;
+  backToHomeLabel?: string | null;
+}
+
+export interface HeroMin {
+  id: number;
+  image?: Media | null;
+  alt?: string | null;
+}
+
+export interface WebsiteLocalization {
   id: number;
   documentId: string;
-  name: string;
-  apiName: string;
-  baseUrl: string;
-  locales: string[];
-  defaultLocale: string;
-  logo?: {
-    url: string;
-    alternativeText: string;
-  };
-  favicon?: {
-    url: string;
-    alternativeText: string;
-  };
-  globalSEO?: SEOMeta;
-  brandColors?: ColorPalette[];
-  createdAt: string;
-  updatedAt: string;
-  publishedAt: string;
+  locale: string;
+  name?: string | null;
+  defaultLocale?: string | null;
+  supportedLocales?: string[] | string | null;
 }
 
-interface Article {
+export interface Article {
   id: number;
   documentId: string;
   title: string;
   slug: string;
-  summary: string;
-  body: string;
-  coverImage?: {
-    url: string;
-    alternativeText: string;
-  };
-  readingTime?: number;
-  seo?: SEOMeta;
-  website?: Website;
+  summary?: string | null;
+  body?: string | null;
+  coverImage?: Media | null;
+  readingTime?: number | null;
+  seo?: SEODefaults | null;
+  website?: Website | null;
   tags?: Tag[];
-  author?: Author;
+  author?: Author | null;
   createdAt: string;
   updatedAt: string;
   publishedAt: string;
+  locale?: string;
   [key: string]: any;
 }
 
-interface Tag {
+export interface Tag {
   id: number;
   documentId: string;
   name: string;
   slug: string;
-  website?: Website;
+  website?: Website | null;
   articles?: Article[];
   createdAt: string;
   updatedAt: string;
   publishedAt: string;
+  locale?: string;
   [key: string]: any;
 }
 
-interface Author {
+export interface Author {
   id: number;
   documentId: string;
   name: string;
   slug: string;
-  bio?: string;
-  avatar?: {
-    url: string;
-    alternativeText: string;
-  };
-  links?: any[];
+  bio?: string | null;
+  avatar?: Media | null;
+  links?: Record<string, unknown>[] | null;
   createdAt: string;
   updatedAt: string;
   publishedAt: string;
+  [key: string]: any;
+}
+
+export interface Website {
+  id: number;
+  documentId: string;
+  apiName: string;
+  name: string;
+  locale: string;
+  defaultLocale: string;
+  supportedLocales: string[];
+  createdAt: string;
+  updatedAt: string;
+  publishedAt: string;
+  brand?: BrandIdentity | null;
+  theme?: ThemePalette | null;
+  homepageHero?: HeroMin | null;
+  seoDefaults?: SEODefaults | null;
+  header?: UIHeader | null;
+  footer?: UIFooter | null;
+  systemLabels?: UISystemLabels | null;
+  articles?: Article[];
+  tags?: Tag[];
+  localizations?: WebsiteLocalization[];
   [key: string]: any;
 }
 
@@ -166,18 +253,355 @@ interface CMSResponse<T> {
   };
 }
 
-export async function getWebsiteData(): Promise<Website | null> {
-  try {
-    const url = `${config.cmsUrl}/api/websites?filters[apiName][$eq]=${config.websiteApiName}&populate=*`;
+function isObject(value: unknown): value is Record<string, any> {
+  return typeof value === 'object' && value !== null;
+}
 
-    const result: CMSResponse<Website[]> = await trackHttpRequest(url, {
-      headers: {
-        'Authorization': `Bearer ${config.cmsApiToken}`,
-        'Content-Type': 'application/json',
-      },
+function unwrapEntity<T>(entity: unknown): T | null {
+  if (!entity) {
+    return null;
+  }
+
+  if (Array.isArray(entity)) {
+    return entity.length > 0 ? unwrapEntity<T>(entity[0]) : null;
+  }
+
+  if (isObject(entity) && 'attributes' in entity && isObject(entity.attributes)) {
+    const { attributes, id, ...rest } = entity as Record<string, any>;
+    return { id, ...attributes, ...rest } as T;
+  }
+
+  return entity as T;
+}
+
+function unwrapSingleRelation<T>(value: unknown): T | null {
+  if (!value) {
+    return null;
+  }
+
+  if (isObject(value) && 'data' in value) {
+    return unwrapEntity<T>((value as Record<string, any>).data);
+  }
+
+  return unwrapEntity<T>(value);
+}
+
+function unwrapCollectionRelation<T>(value: unknown): T[] {
+  if (!value) {
+    return [];
+  }
+
+  if (isObject(value) && 'data' in value) {
+    const data = (value as Record<string, any>).data;
+
+    if (!data) {
+      return [];
+    }
+
+    if (Array.isArray(data)) {
+      return data
+        .map(item => unwrapEntity<T>(item))
+        .filter((entry): entry is T => Boolean(entry));
+    }
+
+    const single = unwrapEntity<T>(data);
+    return single ? [single] : [];
+  }
+
+  if (Array.isArray(value)) {
+    return value
+      .map(item => unwrapEntity<T>(item))
+      .filter((entry): entry is T => Boolean(entry));
+  }
+
+  const single = unwrapEntity<T>(value);
+  return single ? [single] : [];
+}
+
+function ensureStringArray(value: unknown, fallback: string[] = []): string[] {
+  if (Array.isArray(value)) {
+    return value
+      .filter((entry): entry is string => typeof entry === 'string')
+      .map(entry => entry.trim())
+      .filter(entry => entry.length > 0);
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return fallback;
+    }
+
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (Array.isArray(parsed)) {
+        return parsed
+          .filter((entry): entry is string => typeof entry === 'string')
+          .map(entry => entry.trim())
+          .filter(entry => entry.length > 0);
+      }
+    } catch {
+      const csv = trimmed
+        .split(',')
+        .map(token => token.trim())
+        .filter(token => token.length > 0);
+
+      if (csv.length > 0) {
+        return csv;
+      }
+    }
+  }
+
+  return fallback;
+}
+
+function uniqueDefined(values: Array<string | null | undefined>): string[] {
+  const seen = new Set<string>();
+  const ordered: string[] = [];
+
+  for (const value of values) {
+    if (!value) {
+      continue;
+    }
+
+    if (!seen.has(value)) {
+      seen.add(value);
+      ordered.push(value);
+    }
+  }
+
+  return ordered;
+}
+
+function normalizeNavMenuItem(raw: unknown): NavMenuItem | null {
+  const item = unwrapEntity<NavMenuItem>(raw);
+  if (!item || !item.label) {
+    return null;
+  }
+
+  const linkType: LinkType = item.linkType === 'external_url' ? 'external_url' : 'internal_route';
+
+  return {
+    ...item,
+    linkType,
+    path: item.path ?? null,
+    url: item.url ?? null,
+    openInNewTab: item.openInNewTab ?? false,
+  };
+}
+
+function normalizeNavLinkGroup(raw: unknown): NavLinkGroup | null {
+  const group = unwrapEntity<NavLinkGroup>(raw);
+  if (!group) {
+    return null;
+  }
+
+  const links = unwrapCollectionRelation<NavMenuItem>(group.links)
+    .map(normalizeNavMenuItem)
+    .filter((entry): entry is NavMenuItem => Boolean(entry));
+
+  return {
+    ...group,
+    links,
+  };
+}
+
+function normalizeHero(raw: unknown): HeroMin | null {
+  const hero = unwrapEntity<HeroMin>(raw);
+  if (!hero) {
+    return null;
+  }
+
+  return {
+    ...hero,
+    image: unwrapSingleRelation<Media>((hero as any).image ?? hero.image),
+  };
+}
+
+function normalizeAuthor(raw: unknown): Author | null {
+  const author = unwrapEntity<Author>(raw);
+  if (!author) {
+    return null;
+  }
+
+  return {
+    ...author,
+    avatar: unwrapSingleRelation<Media>(author.avatar),
+  };
+}
+
+function normalizeTag(raw: unknown): Tag | null {
+  const tag = unwrapEntity<Tag>(raw);
+  if (!tag) {
+    return null;
+  }
+
+  return {
+    ...tag,
+    website: undefined,
+    articles: [],
+  };
+}
+
+function normalizeArticle(raw: unknown): Article | null {
+  const article = unwrapEntity<Article>(raw);
+  if (!article) {
+    return null;
+  }
+
+  const tags = unwrapCollectionRelation<Tag>(article.tags)
+    .map(normalizeTag)
+    .filter((entry): entry is Tag => Boolean(entry));
+
+  return {
+    ...article,
+    website: undefined,
+    tags,
+    coverImage: unwrapSingleRelation<Media>(article.coverImage),
+    author: normalizeAuthor(article.author) ?? undefined,
+    seo: unwrapSingleRelation<SEODefaults>(article.seo),
+  };
+}
+
+function normalizeWebsite(rawWebsite: unknown): Website {
+  const base = unwrapEntity<Website>(rawWebsite);
+
+  if (!base) {
+    throw new Error('Received invalid website payload from CMS');
+  }
+
+  const brand = unwrapSingleRelation<BrandIdentity>(base.brand);
+  const themeRaw = unwrapSingleRelation<ThemePalette>(base.theme);
+  const paletteRaw = themeRaw?.palette ?? null;
+  const themePalette = paletteRaw
+    ? unwrapSingleRelation<ThemePaletteSet>(paletteRaw) || (isObject(paletteRaw) ? { ...(paletteRaw as ThemePaletteSet) } : null)
+    : null;
+  const theme = themeRaw
+    ? {
+        ...themeRaw,
+        palette: themePalette,
+      }
+    : null;
+
+  const homepageHero = normalizeHero(base.homepageHero);
+  const seoDefaults = unwrapSingleRelation<SEODefaults>(base.seoDefaults);
+
+  const headerRaw = unwrapSingleRelation<UIHeader>(base.header);
+  const header = headerRaw
+    ? {
+        ...headerRaw,
+        primaryNav: unwrapCollectionRelation<NavMenuItem>(headerRaw.primaryNav)
+          .map(normalizeNavMenuItem)
+          .filter((entry): entry is NavMenuItem => Boolean(entry)),
+      }
+    : null;
+
+  const footerRaw = unwrapSingleRelation<UIFooter>(base.footer);
+  const footer = footerRaw
+    ? {
+        ...footerRaw,
+        linkGroups: unwrapCollectionRelation<NavLinkGroup>(footerRaw.linkGroups)
+          .map(normalizeNavLinkGroup)
+          .filter((entry): entry is NavLinkGroup => Boolean(entry)),
+      }
+    : null;
+
+  const systemLabels = unwrapSingleRelation<UISystemLabels>(base.systemLabels);
+
+  const articles = unwrapCollectionRelation<Article>(base.articles)
+    .map(normalizeArticle)
+    .filter((entry): entry is Article => Boolean(entry))
+    .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+
+  const tags = unwrapCollectionRelation<Tag>(base.tags)
+    .map(normalizeTag)
+    .filter((entry): entry is Tag => Boolean(entry))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  const localizationEntries = unwrapCollectionRelation<WebsiteLocalization>(base.localizations).map(localization => ({
+    ...localization,
+    supportedLocales: ensureStringArray(localization.supportedLocales, []),
+  }));
+
+  const supportedLocales = uniqueDefined([
+    base.defaultLocale,
+    ...ensureStringArray(base.supportedLocales, []),
+    base.locale,
+    ...localizationEntries.map(entry => entry.locale),
+  ]);
+
+  return {
+    ...base,
+    brand,
+    theme,
+    homepageHero,
+    seoDefaults,
+    header,
+    footer,
+    systemLabels,
+    articles,
+    tags,
+    localizations: localizationEntries,
+    supportedLocales,
+  };
+}
+
+export function resolveCmsAssetUrl(media?: Media | null): string | null {
+  if (!media?.url) {
+    return null;
+  }
+
+  if (media.url.startsWith('http')) {
+    return media.url;
+  }
+
+  if (!config.cmsUrl) {
+    console.warn('Missing CMS_URL env. Returning relative asset path for media.');
+    return media.url;
+  }
+
+  const normalizedBase = config.cmsUrl.replace(/\/$/, '');
+  return `${normalizedBase}${media.url}`;
+}
+
+export async function getWebsiteData(locale?: string): Promise<Website | null> {
+  try {
+    if (!config.cmsUrl) {
+      console.error('CMS_URL env is not configured. Unable to fetch website data.');
+      return null;
+    }
+
+    const params = new URLSearchParams();
+    if (config.websiteApiName) {
+      params.set('filters[apiName][$eq]', config.websiteApiName);
+    }
+    params.set('populate[brand][populate]', '*');
+    params.set('populate[theme][populate]', 'palette');
+    params.set('populate[homepageHero][populate]', '*');
+    params.set('populate[seoDefaults]', '*');
+    params.set('populate[header][populate][primaryNav]', '*');
+    params.set('populate[footer][populate][linkGroups][populate][links]', '*');
+    params.set('populate[systemLabels]', '*');
+    params.set('populate[articles][populate]', 'coverImage,tags,author,seo');
+    params.set('populate[tags]', '*');
+    params.set('publicationState', 'live');
+
+    if (locale) {
+      params.set('locale', locale);
+    }
+
+    const baseUrl = config.cmsUrl.replace(/\/$/, '');
+    const url = `${baseUrl}/api/websites?${params.toString()}`;
+
+    const result = await trackHttpRequest<CMSResponse<Website[]>>(url, {
+      headers: buildCmsHeaders(),
     });
 
-    return result.data.length > 0 ? result.data[0] : null;
+    if (!result.data || result.data.length === 0) {
+      return null;
+    }
+
+    return normalizeWebsite(result.data[0]);
   } catch (error) {
     console.error('Error fetching website data:', error);
     return null;
@@ -186,21 +610,36 @@ export async function getWebsiteData(): Promise<Website | null> {
 
 export async function getArticles(locale?: string): Promise<Article[]> {
   try {
-    let url = `${config.cmsUrl}/api/articles?filters[website][apiName][$eq]=${config.websiteApiName}&populate=*&sort=updatedAt:desc&pagination[page]=1&pagination[pageSize]=100`;
-
-    // Add locale parameter if provided
-    if (locale) {
-      url += `&locale=${locale}`;
+    if (!config.cmsUrl) {
+      console.error('CMS_URL env is not configured. Unable to fetch articles.');
+      return [];
     }
 
-    const result: CMSResponse<Article[]> = await trackHttpRequest(url, {
-      headers: {
-        'Authorization': `Bearer ${config.cmsApiToken}`,
-        'Content-Type': 'application/json',
-      },
+    const params = new URLSearchParams();
+    if (config.websiteApiName) {
+      params.set('filters[website][apiName][$eq]', config.websiteApiName);
+    }
+    params.set('populate', 'coverImage,tags,author,seo');
+    params.set('sort', 'updatedAt:desc');
+    params.set('pagination[page]', '1');
+    params.set('pagination[pageSize]', '100');
+    params.set('publicationState', 'live');
+
+    if (locale) {
+      params.set('locale', locale);
+    }
+
+    const baseUrl = config.cmsUrl.replace(/\/$/, '');
+    const url = `${baseUrl}/api/articles?${params.toString()}`;
+
+    const result = await trackHttpRequest<CMSResponse<Article[]>>(url, {
+      headers: buildCmsHeaders(),
     });
 
-    return result.data;
+    const rawArticles = Array.isArray(result.data) ? result.data : [];
+    return rawArticles
+      .map(normalizeArticle)
+      .filter((entry): entry is Article => Boolean(entry));
   } catch (error) {
     console.error('Error fetching articles:', error);
     return [];
@@ -209,21 +648,36 @@ export async function getArticles(locale?: string): Promise<Article[]> {
 
 export async function getTags(locale?: string): Promise<Tag[]> {
   try {
-    let url = `${config.cmsUrl}/api/tags?filters[website][apiName][$eq]=${config.websiteApiName}&populate=*&sort=updatedAt:desc&pagination[page]=1&pagination[pageSize]=100`;
-
-    // Add locale parameter if provided
-    if (locale) {
-      url += `&locale=${locale}`;
+    if (!config.cmsUrl) {
+      console.error('CMS_URL env is not configured. Unable to fetch tags.');
+      return [];
     }
 
-    const result: CMSResponse<Tag[]> = await trackHttpRequest(url, {
-      headers: {
-        'Authorization': `Bearer ${config.cmsApiToken}`,
-        'Content-Type': 'application/json',
-      },
+    const params = new URLSearchParams();
+    if (config.websiteApiName) {
+      params.set('filters[website][apiName][$eq]', config.websiteApiName);
+    }
+    params.set('populate', 'articles');
+    params.set('sort', 'updatedAt:desc');
+    params.set('pagination[page]', '1');
+    params.set('pagination[pageSize]', '100');
+    params.set('publicationState', 'live');
+
+    if (locale) {
+      params.set('locale', locale);
+    }
+
+    const baseUrl = config.cmsUrl.replace(/\/$/, '');
+    const url = `${baseUrl}/api/tags?${params.toString()}`;
+
+    const result = await trackHttpRequest<CMSResponse<Tag[]>>(url, {
+      headers: buildCmsHeaders(),
     });
 
-    return result.data;
+    const rawTags = Array.isArray(result.data) ? result.data : [];
+    return rawTags
+      .map(normalizeTag)
+      .filter((entry): entry is Tag => Boolean(entry));
   } catch (error) {
     console.error('Error fetching tags:', error);
     return [];
@@ -232,16 +686,29 @@ export async function getTags(locale?: string): Promise<Tag[]> {
 
 export async function getAuthors(): Promise<Author[]> {
   try {
-    const url = `${config.cmsUrl}/api/authors?populate=*&sort=name:asc&pagination[page]=1&pagination[pageSize]=100`;
+    if (!config.cmsUrl) {
+      console.error('CMS_URL env is not configured. Unable to fetch authors.');
+      return [];
+    }
 
-    const result: CMSResponse<Author[]> = await trackHttpRequest(url, {
-      headers: {
-        'Authorization': `Bearer ${config.cmsApiToken}`,
-        'Content-Type': 'application/json',
-      },
+    const params = new URLSearchParams();
+    params.set('populate', 'avatar');
+    params.set('sort', 'name:asc');
+    params.set('pagination[page]', '1');
+    params.set('pagination[pageSize]', '100');
+    params.set('publicationState', 'live');
+
+    const baseUrl = config.cmsUrl.replace(/\/$/, '');
+    const url = `${baseUrl}/api/authors?${params.toString()}`;
+
+    const result = await trackHttpRequest<CMSResponse<Author[]>>(url, {
+      headers: buildCmsHeaders(),
     });
 
-    return result.data;
+    const rawAuthors = Array.isArray(result.data) ? result.data : [];
+    return rawAuthors
+      .map(normalizeAuthor)
+      .filter((entry): entry is Author => Boolean(entry));
   } catch (error) {
     console.error('Error fetching authors:', error);
     return [];


### PR DESCRIPTION
## Summary
- normalize Strapi website responses by flattening nested relations, parsing locale lists, and reusing article/tag/author normalizers across CMS calls
- derive localized article and tag collections directly from the populated website payload while updating UI copy to lean exclusively on CMS-provided labels
- simplify the global layout footer so that all visible copy comes from Strapi-managed fields

## Testing
- npm run astro -- check *(fails: requires @astrojs/check and typescript packages which cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d2512dd8808327b596e612f25b091c