### PR TITLE
Modularize localized homepage layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,8 @@
 ## Project Structure & Module Organization
 The Astro app lives under `src`, with route files in `src/pages` and localized content served from `src/pages/[lang]/index.astro`. Shared UI lives in `src/components`, long-form layouts in `src/layouts`, and CMS/API accessors in `src/services/cms.ts`. Utilities such as locale helpers belong in `src/utils`, while static assets reside in `public`. Build and TypeScript settings are centralized in `astro.config.mjs` and `tsconfig.json`.
 
+Key homepage elements (navigation, hero, article grid, CMS fallback) are now extracted into dedicated components under `src/components`. New UI work should follow this component-first approach so that pages focus on data loading and orchestration while presentation logic remains encapsulated and reusable.
+
 ## Build, Test, and Development Commands
 Install dependencies with `npm install`. Run `npm run dev` for the local development server, `npm run build` to generate the static site in `dist`, and `npm run preview` to verify the production build. Use `npm run astro -- check` to lint Astro/TypeScript templates and surface configuration issues before committing.
 

--- a/src/components/ArticleCard.astro
+++ b/src/components/ArticleCard.astro
@@ -1,0 +1,219 @@
+---
+import { config } from '../config';
+
+interface ArticleTag {
+  name: string;
+}
+
+interface ArticleCover {
+  url?: string | null;
+  alternativeText?: string | null;
+}
+
+interface ArticleRecord {
+  title: string;
+  slug: string;
+  summary?: string | null;
+  updatedAt: string;
+  readingTime?: number | null;
+  tags?: ArticleTag[];
+  coverImage?: ArticleCover | null;
+}
+
+type Variant = 'featured' | 'small' | 'medium';
+
+interface Props {
+  article: ArticleRecord;
+  locale: string;
+  variant?: Variant;
+  readMoreLabel: string;
+  summaryFallback: string;
+}
+
+const {
+  article,
+  locale,
+  variant = 'medium',
+  readMoreLabel,
+  summaryFallback,
+} = Astro.props as Props;
+
+function resolveMediaUrl(path?: string | null): string | null {
+  if (!path) return null;
+  if (/^https?:\/\//i.test(path)) {
+    return path;
+  }
+  if (!config.cmsUrl) {
+    return path;
+  }
+  const normalizedBase = config.cmsUrl.replace(/\/$/, '');
+  return `${normalizedBase}${path}`;
+}
+
+const coverImageUrl = resolveMediaUrl(article.coverImage?.url) ?? '/images/placeholder.jpg';
+const coverAlt = article.coverImage?.alternativeText || article.title;
+const articleHref = `/${locale}/articles/${article.slug}`.replace(/\/+/, '/');
+const formattedDate = new Date(article.updatedAt).toLocaleDateString(locale || 'en', {
+  year: 'numeric',
+  month: 'short',
+  day: 'numeric',
+});
+const summaryText = article.summary || summaryFallback;
+const tagLabel = article.tags?.[0]?.name;
+---
+
+<article class={`article-card ${variant}`}>
+  <img src={coverImageUrl} alt={coverAlt} class="article-image" loading="lazy" />
+  <div class="article-content">
+    <div class="article-meta">
+      <span>📅 {formattedDate}</span>
+      {article.readingTime && <span>⏱ {article.readingTime} min read</span>}
+      {tagLabel && <span>🏷️ {tagLabel}</span>}
+    </div>
+    <h3 class="article-title">
+      <a href={articleHref}>{article.title}</a>
+    </h3>
+    <p class={`article-summary${article.summary ? '' : ' placeholder'}`}>
+      {summaryText}
+    </p>
+    <a href={articleHref} class="read-more">
+      {readMoreLabel}
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <path d="m9 18 6-6-6-6" />
+      </svg>
+    </a>
+  </div>
+</article>
+
+<style>
+  .article-card {
+    background: white;
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+    transition: transform 0.3s, box-shadow 0.3s;
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+  }
+
+  .article-card:hover {
+    transform: translateY(-6px);
+    box-shadow: 0 14px 32px rgba(0, 0, 0, 0.18);
+  }
+
+  .article-image {
+    width: 100%;
+    height: 240px;
+    object-fit: cover;
+    transition: transform 0.3s ease;
+  }
+
+  .article-card:hover .article-image {
+    transform: scale(1.03);
+  }
+
+  .article-content {
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    flex: 1;
+  }
+
+  .article-meta {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    font-size: 0.85rem;
+    color: #6b7280;
+    flex-wrap: wrap;
+  }
+
+  .article-title {
+    font-size: 1.5rem;
+    font-weight: 600;
+    margin: 0;
+    line-height: 1.35;
+  }
+
+  .article-title a {
+    color: #1f2937;
+    text-decoration: none;
+    transition: color 0.2s ease;
+    display: inline-block;
+  }
+
+  .article-title a:hover {
+    color: #ff6b35;
+  }
+
+  .article-summary {
+    color: #6b7280;
+    line-height: 1.6;
+    margin: 0;
+  }
+
+  .article-summary.placeholder {
+    opacity: 0.7;
+    font-style: italic;
+  }
+
+  .read-more {
+    color: #ff6b35;
+    font-weight: 500;
+    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    transition: gap 0.2s ease;
+    margin-top: auto;
+  }
+
+  .read-more:hover {
+    gap: 0.75rem;
+  }
+
+  .article-card.small .article-image {
+    height: 160px;
+  }
+
+  .article-card.small .article-content {
+    padding: 1.25rem;
+  }
+
+  .article-card.small .article-title {
+    font-size: 1.25rem;
+  }
+
+  .article-card.medium .article-image {
+    height: 200px;
+  }
+
+  .article-card.featured .article-image {
+    height: 300px;
+  }
+
+  .article-card.featured .article-content {
+    padding: 1.75rem;
+  }
+
+  .article-card.featured .article-title {
+    font-size: 2rem;
+  }
+
+  @media (max-width: 768px) {
+    .article-image {
+      height: 220px;
+    }
+
+    .article-card.featured .article-image {
+      height: 240px;
+    }
+
+    .article-card.featured .article-title {
+      font-size: 1.6rem;
+    }
+  }
+</style>

--- a/src/components/ArticleGrid.astro
+++ b/src/components/ArticleGrid.astro
@@ -1,0 +1,119 @@
+---
+import ArticleCard from './ArticleCard.astro';
+
+interface ArticleRecord {
+  title: string;
+  slug: string;
+  summary?: string | null;
+  updatedAt: string;
+  readingTime?: number | null;
+  tags?: Array<{ name: string }>;
+  coverImage?: { url?: string | null; alternativeText?: string | null } | null;
+}
+
+interface Props {
+  articles: ArticleRecord[];
+  locale: string;
+  readMoreLabel: string;
+  summaryFallback: string;
+}
+
+const {
+  articles = [],
+  locale,
+  readMoreLabel,
+  summaryFallback,
+} = Astro.props as Props;
+
+const featuredArticle = articles[0];
+const secondaryArticles = articles.slice(1, 3);
+const additionalArticles = articles.slice(3, 6);
+---
+
+<div class="articles-grid">
+  {featuredArticle && (
+    <ArticleCard
+      article={featuredArticle}
+      locale={locale}
+      variant="featured"
+      readMoreLabel={readMoreLabel}
+      summaryFallback={summaryFallback}
+    />
+  )}
+
+  <div class="articles-right-column">
+    {secondaryArticles.map((article) => (
+      <ArticleCard
+        article={article}
+        locale={locale}
+        variant="small"
+        readMoreLabel={readMoreLabel}
+        summaryFallback={summaryFallback}
+      />
+    ))}
+  </div>
+</div>
+
+{additionalArticles.length > 0 && (
+  <div class="articles-row-three">
+    {additionalArticles.map((article) => (
+      <ArticleCard
+        article={article}
+        locale={locale}
+        variant="medium"
+        readMoreLabel={readMoreLabel}
+        summaryFallback={summaryFallback}
+      />
+    ))}
+  </div>
+)}
+
+<style>
+  .articles-grid {
+    display: grid;
+    grid-template-columns: 2fr 1fr;
+    gap: 2rem;
+  }
+
+  .articles-right-column {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+  }
+
+  .articles-row-three {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 2rem;
+    margin-top: 3rem;
+  }
+
+  @media (max-width: 1024px) {
+    .articles-grid {
+      grid-template-columns: 1fr;
+    }
+
+    .articles-right-column {
+      flex-direction: row;
+      gap: 1.5rem;
+    }
+
+    .articles-right-column > :global(article) {
+      flex: 1;
+    }
+
+    .articles-row-three {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  }
+
+  @media (max-width: 768px) {
+    .articles-right-column {
+      flex-direction: column;
+    }
+
+    .articles-row-three {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/src/components/HeroSection.astro
+++ b/src/components/HeroSection.astro
@@ -1,0 +1,131 @@
+---
+interface Props {
+  title: string;
+  tagline?: string;
+  backgroundUrl?: string | null;
+  primaryColor: string;
+  secondaryColor: string;
+  ctaLabel: string;
+  ctaHref: string;
+  srText?: string;
+}
+
+const {
+  title,
+  tagline,
+  backgroundUrl,
+  primaryColor,
+  secondaryColor,
+  ctaLabel,
+  ctaHref,
+  srText,
+} = Astro.props as Props;
+
+const backgroundLayers = backgroundUrl
+  ? `linear-gradient(135deg, rgba(17, 24, 39, 0.72), rgba(17, 24, 39, 0.55)), url('${backgroundUrl}')`
+  : `linear-gradient(135deg, ${primaryColor}, ${secondaryColor})`;
+---
+
+<section class="hero" style={`background-image: ${backgroundLayers};`}>
+  {backgroundUrl && srText && <span class="sr-only">{srText}</span>}
+  <div class="hero-content">
+    <h1>{title}</h1>
+    {tagline && <p>{tagline}</p>}
+    <div class="hero-buttons">
+      <a href={ctaHref} class="btn-hero btn-primary">
+        {ctaLabel}
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="m9 18 6-6-6-6" />
+        </svg>
+      </a>
+    </div>
+  </div>
+</section>
+
+<style define:vars={{ primary: primaryColor, secondary: secondaryColor }}>
+  .hero {
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
+    min-height: 60vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    color: white;
+    position: relative;
+    width: 100%;
+    box-sizing: border-box;
+  }
+
+  .hero-content {
+    max-width: 640px;
+    padding: 2rem;
+  }
+
+  .hero h1 {
+    font-size: clamp(2.5rem, 5vw, 4rem);
+    font-weight: 700;
+    margin-bottom: 1.5rem;
+    line-height: 1.15;
+  }
+
+  .hero p {
+    font-size: 1.2rem;
+    margin-bottom: 2rem;
+    opacity: 0.9;
+    line-height: 1.6;
+  }
+
+  .hero-buttons {
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+  }
+
+  .btn-hero {
+    padding: 0.85rem 2rem;
+    border-radius: 8px;
+    font-weight: 600;
+    text-decoration: none;
+    transition: all 0.3s ease;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .btn-primary {
+    background: var(--primary, #ff6b35);
+    color: white;
+  }
+
+  .btn-hero:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 25px rgba(0, 0, 0, 0.2);
+  }
+
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  @media (max-width: 768px) {
+    .hero {
+      min-height: 50vh;
+    }
+
+    .btn-hero {
+      width: 100%;
+      max-width: 280px;
+      justify-content: center;
+    }
+  }
+</style>

--- a/src/components/NavigationBar.astro
+++ b/src/components/NavigationBar.astro
@@ -1,0 +1,144 @@
+---
+import LanguageSelector from './LanguageSelector.astro';
+
+interface NavLink {
+  label: string;
+  href: string;
+  openInNewTab?: boolean;
+}
+
+interface Props {
+  homeHref: string;
+  brandLogoUrl?: string | null;
+  brandLogoAlt?: string | null;
+  brandDisplayName: string;
+  navLinks: NavLink[];
+  availableLocales: string[];
+  currentLocale: string;
+  currentPath: string;
+  accentColor: string;
+  showLanguageSelector?: boolean;
+}
+
+const {
+  homeHref,
+  brandLogoUrl,
+  brandLogoAlt,
+  brandDisplayName,
+  navLinks,
+  availableLocales,
+  currentLocale,
+  currentPath,
+  accentColor,
+  showLanguageSelector = true,
+} = Astro.props as Props;
+
+const shouldRenderSelector = showLanguageSelector && availableLocales.length > 0;
+---
+
+<nav class="navbar">
+  <a href={homeHref} class="navbar-brand">
+    {brandLogoUrl && (
+      <img src={brandLogoUrl} alt={brandLogoAlt || `${brandDisplayName} logo`} class="navbar-logo" loading="lazy" />
+    )}
+    <span class="navbar-title">{brandDisplayName}</span>
+  </a>
+
+  {navLinks.length > 0 && (
+    <ul class="navbar-nav">
+      {navLinks.map((link) => (
+        <li>
+          <a
+            href={link.href}
+            target={link.openInNewTab ? '_blank' : undefined}
+            rel={link.openInNewTab ? 'noopener noreferrer' : undefined}
+          >
+            {link.label}
+          </a>
+        </li>
+      ))}
+    </ul>
+  )}
+
+  <div class="navbar-actions">
+    {shouldRenderSelector && (
+      <LanguageSelector
+        availableLocales={availableLocales}
+        currentLang={currentLocale}
+        currentPath={currentPath}
+      />
+    )}
+  </div>
+</nav>
+
+<style define:vars={{ accent: accentColor }}>
+  .navbar {
+    background: white;
+    border-bottom: 1px solid #e5e7eb;
+    padding: 1rem 2rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+    box-sizing: border-box;
+    gap: 1.5rem;
+  }
+
+  .navbar-brand {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--accent, #ff6b35);
+    text-decoration: none;
+    white-space: nowrap;
+  }
+
+  .navbar-logo {
+    height: 28px;
+    width: auto;
+  }
+
+  .navbar-title {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+  }
+
+  .navbar-nav {
+    display: flex;
+    gap: 1.75rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .navbar-nav a {
+    color: #4b5563;
+    text-decoration: none;
+    font-weight: 500;
+    transition: color 0.2s ease;
+  }
+
+  .navbar-nav a:hover {
+    color: var(--accent, #ff6b35);
+  }
+
+  .navbar-actions {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+  }
+
+  @media (max-width: 768px) {
+    .navbar {
+      padding: 1rem;
+      flex-wrap: wrap;
+    }
+
+    .navbar-nav {
+      display: none;
+    }
+  }
+</style>

--- a/src/components/NoWebsiteFallback.astro
+++ b/src/components/NoWebsiteFallback.astro
@@ -1,0 +1,46 @@
+---
+const message = Astro.props?.message || 'Unable to load website data from CMS. Please check your environment variables and ensure your CMS is properly configured.';
+---
+
+<div class="fallback">
+  <svg width="80" height="80" viewBox="0 0 24 24" fill="none" stroke="var(--accent, #ff6b35)" stroke-width="1.5">
+    <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+    <line x1="12" y1="9" x2="12" y2="13" />
+    <line x1="12" y1="17" x2="12.01" y2="17" />
+  </svg>
+  <h1>Welcome to Astro</h1>
+  <div class="fallback-panel">
+    <h3>Configuration Required</h3>
+    <p>{message}</p>
+  </div>
+</div>
+
+<style>
+  .fallback {
+    text-align: center;
+    padding: 5rem 2rem;
+    display: grid;
+    justify-items: center;
+    gap: 1.5rem;
+  }
+
+  .fallback-panel {
+    background: #f3f4f6;
+    padding: 2rem;
+    border-radius: 12px;
+    border-left: 4px solid var(--accent, #ff6b35);
+    max-width: 640px;
+    text-align: left;
+  }
+
+  .fallback-panel h3 {
+    margin: 0 0 0.5rem;
+    color: var(--accent, #ff6b35);
+  }
+
+  .fallback-panel p {
+    color: #4b5563;
+    line-height: 1.6;
+    margin: 0;
+  }
+</style>

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -1,7 +1,10 @@
 ---
 import Layout from '../../layouts/Layout.astro';
 import DebugPanel from '../../components/DebugPanel.astro';
-import LanguageSelector from '../../components/LanguageSelector.astro';
+import NavigationBar from '../../components/NavigationBar.astro';
+import HeroSection from '../../components/HeroSection.astro';
+import ArticleGrid from '../../components/ArticleGrid.astro';
+import NoWebsiteFallback from '../../components/NoWebsiteFallback.astro';
 import { config } from '../../config';
 import { getWebsiteData, getLocalizedWebsiteData, getArticles, getTags } from '../../services/cms';
 import type { NavMenuItem } from '../../services/cms';
@@ -98,13 +101,25 @@ const surfaceColor = themePalette?.surface ?? '#F6F7F9';
 const textColor = themePalette?.neutral ?? '#111827';
 const mutedColor = themePalette?.muted ?? '#6b7280';
 
+function resolveMediaUrl(path?: string | null): string | null {
+  if (!path) return null;
+  if (/^https?:\/\//i.test(path)) {
+    return path;
+  }
+  if (!config.cmsUrl) {
+    return path;
+  }
+  const normalizedBase = config.cmsUrl.replace(/\/$/, '');
+  return `${normalizedBase}${path}`;
+}
+
 const brandDisplayName = websiteData?.header?.brandDisplayName ?? websiteData?.name ?? 'Multisite Travel';
 const tagline = websiteData?.header?.tagline ?? websiteData?.seoDefaults?.metaDescription ?? '';
 const heroImageSource = websiteData?.homepageHero?.image ?? null;
 const heroBackgroundUrl = resolveMediaUrl(heroImageSource?.fullUrl ?? heroImageSource?.url) ?? null;
 const heroImageAlt = websiteData?.homepageHero?.alt ?? brandDisplayName;
 const brandLogo = websiteData?.brand?.logo ?? null;
-const brandLogoUrl = brandLogo?.fullUrl ?? brandLogo?.url ?? null;
+const brandLogoUrl = resolveMediaUrl(brandLogo?.fullUrl ?? brandLogo?.url) ?? null;
 
 const readMoreLabel = websiteData?.systemLabels?.readMoreLabel ?? 'Read more';
 const searchPlaceholder = websiteData?.systemLabels?.searchPlaceholder ?? 'Search articles…';
@@ -128,6 +143,18 @@ function resolveNavHref(item: NavMenuItem, locale: string): string {
   return localized.replace(/\/+$/, '') || `/${locale}`;
 }
 
+const navLinks = primaryNav.length > 0
+  ? primaryNav.map((item) => ({
+      label: item.label,
+      href: resolveNavHref(item, activeLocale),
+      openInNewTab: Boolean(item.openInNewTab || item.linkType === 'external_url'),
+    }))
+  : tags.slice(0, 5).map((tag) => ({
+      label: tag.name,
+      href: `/${activeLocale}/tag/${tag.slug}`,
+      openInNewTab: false,
+    }));
+
 function resolveMediaUrl(path?: string | null): string | null {
   if (!path) return null;
   if (/^https?:\/\//i.test(path)) {
@@ -140,203 +167,21 @@ function resolveMediaUrl(path?: string | null): string | null {
   return `${normalizedBase}${path}`;
 }
 
-function getCoverImageUrl(media?: { url?: string | null } | null): string | null {
-  if (!media || !media.url) {
-    return null;
-  }
-  return resolveMediaUrl(media.url);
-}
-const heroOverlay = 'linear-gradient(135deg, rgba(17, 24, 39, 0.72), rgba(17, 24, 39, 0.55))';
-const heroGradient = `linear-gradient(135deg, ${brandColor}, ${secondaryColor})`;
-const heroBackgroundStyle = heroBackgroundUrl
-  ? `background-image: ${heroOverlay}, url('${heroBackgroundUrl}');`
-  : `background-image: ${heroGradient};`;
 ---
 
 <Layout title={seoTitle} websiteData={websiteData} currentLocale={activeLocale}>
 
 	<style define:vars={{
-		primary: brandColor,
-		secondary: secondaryColor,
 		background: backgroundColor,
 		text: textColor,
 		surface: surfaceColor,
 		muted: mutedColor
 	}}>
-		/* Wanderlust-inspired styles - CMS driven */
-		:root {
-			--orange: var(--primary);
-			--blue: var(--secondary);
-			--border-radius: 8px;
-			--text-secondary: var(--muted);
-		}
-
-		.sr-only {
-			position: absolute;
-			width: 1px;
-			height: 1px;
-			padding: 0;
-			margin: -1px;
-			overflow: hidden;
-			clip: rect(0, 0, 0, 0);
-			white-space: nowrap;
-			border: 0;
-		}
-
-		body {
-			margin: 0;
-			padding: 0;
-			font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
-			background: var(--background);
-			color: var(--text);
-		}
-
-		/* Navigation Header */
-		.navbar {
-			background: white;
-			border-bottom: 1px solid #e5e7eb;
-			padding: 1rem 2rem;
-			display: flex;
-			justify-content: space-between;
-			align-items: center;
-			width: 100%;
-			box-sizing: border-box;
-		}
-
-		.navbar-brand {
-			display: flex;
-			align-items: center;
-			gap: 0.5rem;
-			font-size: 1.5rem;
-			font-weight: 700;
-			color: var(--orange);
-			text-decoration: none;
-		}
-
-		.navbar-nav {
-			display: flex;
-			gap: 2rem;
-			list-style: none;
-			margin: 0;
-			padding: 0;
-		}
-
-		.navbar-nav a {
-			color: #4b5563;
-			text-decoration: none;
-			font-weight: 500;
-			transition: color 0.2s;
-		}
-
-		.navbar-nav a:hover {
-			color: var(--orange);
-		}
-
-		.navbar-actions {
-			display: flex;
-			align-items: center;
-			gap: 1rem;
-		}
-
-		.btn-subscribe {
-			background: transparent;
-			color: #4b5563;
-			border: none;
-			cursor: pointer;
-			font-weight: 500;
-		}
-
-		.btn-start {
-			background: var(--orange);
-			color: white;
-			padding: 0.5rem 1.5rem;
-			border: none;
-			border-radius: 6px;
-			cursor: pointer;
-			font-weight: 500;
-			transition: transform 0.2s;
-		}
-
-		.btn-start:hover {
-			transform: translateY(-1px);
-		}
-
-		/* Hero Section */
-		.hero {
-			background-image: linear-gradient(135deg, var(--primary), var(--secondary));
-			background-size: cover;
-			background-position: center;
-			background-repeat: no-repeat;
-			min-height: 60vh;
-			display: flex;
-			align-items: center;
-			justify-content: center;
-			text-align: center;
-			color: white;
-			position: relative;
-			width: 100%;
-			box-sizing: border-box;
-		}
-
-		.hero-content {
-			max-width: 600px;
-			padding: 2rem;
-		}
-
-		.hero h1 {
-			font-size: clamp(2.5rem, 5vw, 4rem);
-			font-weight: 700;
-			margin-bottom: 1.5rem;
-			line-height: 1.2;
-		}
-
-		.hero p {
-			font-size: 1.25rem;
-			margin-bottom: 2rem;
-			opacity: 0.9;
-			line-height: 1.6;
-		}
-
-		.hero-buttons {
-			display: flex;
-			gap: 1rem;
-			justify-content: center;
-			flex-wrap: wrap;
-		}
-
-		.btn-hero {
-			padding: 0.875rem 2rem;
-			border-radius: 8px;
-			font-weight: 600;
-			text-decoration: none;
-			transition: all 0.3s;
-			display: inline-flex;
-			align-items: center;
-			gap: 0.5rem;
-		}
-
-		.btn-primary {
-			background: var(--orange);
-			color: white;
-		}
-
-		.btn-secondary {
-			background: rgba(255, 255, 255, 0.2);
-			color: white;
-			border: 2px solid rgba(255, 255, 255, 0.3);
-			backdrop-filter: blur(10px);
-		}
-
-		.btn-hero:hover {
-			transform: translateY(-2px);
-			box-shadow: 0 8px 25px rgba(0,0,0,0.2);
-		}
-
-		/* Main Content */
-		.container {
+		.page-container {
 			max-width: 1200px;
 			margin: 0 auto;
 			padding: 0 2rem;
+			box-sizing: border-box;
 		}
 
 		.section {
@@ -344,7 +189,7 @@ const heroBackgroundStyle = heroBackgroundUrl
 		}
 
 		.section-title {
-			font-size: 2.5rem;
+			font-size: 2.4rem;
 			font-weight: 700;
 			text-align: center;
 			margin-bottom: 1rem;
@@ -352,458 +197,78 @@ const heroBackgroundStyle = heroBackgroundUrl
 		}
 
 		.section-subtitle {
-			font-size: 1.125rem;
+			font-size: 1.1rem;
 			color: #6b7280;
 			text-align: center;
-			max-width: 600px;
+			max-width: 640px;
 			margin: 0 auto 3rem;
 			line-height: 1.6;
 		}
 
-		/* Article Grid */
-		.articles-grid {
-			display: grid;
-			grid-template-columns: 2fr 1fr;
-			gap: 2rem;
-			margin-top: 2rem;
-		}
-
-		.article-card {
-			background: white;
-			border-radius: 12px;
-			overflow: hidden;
-			box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
-			transition: transform 0.3s, box-shadow 0.3s;
-			position: relative;
-			display: flex;
-			flex-direction: column;
-			height: auto;
-		}
-
-		.article-card:hover {
-			transform: translateY(-8px);
-			box-shadow: 0 20px 40px rgba(0, 0, 0, 0.15);
-		}
-
-		.article-image {
-			width: 100%;
-			height: 240px;
-			object-fit: cover;
-			transition: transform 0.3s;
-		}
-
-		.article-card:hover .article-image {
-			transform: scale(1.05);
-		}
-
-		.article-content {
-			padding: 1.5rem;
-			display: flex;
-			flex-direction: column;
-			gap: 0.75rem;
-			flex: 1;
-		}
-
-		.article-meta {
-			display: flex;
-			align-items: center;
-			gap: 1rem;
-			margin-bottom: 1rem;
-			font-size: 0.875rem;
+		.empty-state {
+			text-align: center;
 			color: #6b7280;
-			flex-wrap: wrap;
+			padding: 3rem 0;
 		}
 
-			.article-title {
-				font-size: 1.65rem;
-				font-weight: 600;
-				margin-bottom: 1rem;
-				line-height: 1.4;
-				display: -webkit-box;
-			-webkit-box-orient: vertical;
-			-webkit-line-clamp: 3;
-			overflow: hidden;
-		}
-
-		.article-title a {
-			color: #1f2937;
-			text-decoration: none;
-			transition: color 0.2s;
-			display: block;
-		}
-
-		.article-title a:hover {
-			color: var(--orange);
-		}
-
-		.article-summary {
-			color: #6b7280;
-			line-height: 1.6;
-			margin-bottom: 1rem;
-			display: -webkit-box;
-			-webkit-box-orient: vertical;
-			-webkit-line-clamp: 3;
-			overflow: hidden;
-			min-height: calc(1.6em * 3);
-		}
-
-		.article-summary.placeholder {
-			opacity: 0.7;
-			font-style: italic;
-		}
-
-		.read-more {
-			color: var(--orange);
-			font-weight: 500;
-			text-decoration: none;
-			display: inline-flex;
-			align-items: center;
-			gap: 0.5rem;
-			transition: gap 0.2s;
-			margin-top: auto;
-		}
-
-		.read-more:hover {
-			gap: 0.75rem;
-		}
-
-		/* Right column for smaller articles */
-		.articles-right-column {
-			display: flex;
-			flex-direction: column;
-			gap: 2rem;
-		}
-
-		/* Large feature card */
-			.article-card.featured {
-				min-height: 500px;
-			}
-
-			.article-card.featured .article-image {
-				height: 300px;
-			}
-
-			.article-card.featured .article-title {
-				font-size: 2rem;
-				line-height: 1.2;
-				margin-bottom: 0.75rem;
-			}
-
-		.article-card.featured .article-summary {
-			font-size: 1.05rem;
-			-webkit-line-clamp: 3;
-			min-height: calc(1.6em * 3);
-		}
-
-		/* Smaller article cards in right column */
-		.article-card.small {
-			height: auto;
-			min-height: 240px;
-		}
-
-		.article-card.small .article-image {
-			height: 140px;
-		}
-
-			.article-card.small .article-title {
-				font-size: 1.2rem;
-				margin-bottom: 0.35rem;
-				-webkit-line-clamp: 2;
-			}
-
-		.article-card.small .article-meta {
-			font-size: 0.75rem;
-			margin-bottom: 0.75rem;
-		}
-
-		.article-card.small .article-summary {
-			-webkit-line-clamp: 2;
-			font-size: 0.95rem;
-			margin-bottom: 0.75rem;
-			line-height: 1.5;
-			min-height: calc(1.5em * 2);
-		}
-
-		.article-card.small .article-content {
-			padding: 1rem;
-		}
-
-		/* Row of 3 articles */
-		.articles-row-three {
-			display: grid;
-			grid-template-columns: repeat(3, 1fr);
-			gap: 2rem;
-			margin-top: 3rem;
-		}
-
-			.article-card.medium {
-				height: auto;
-				min-height: 350px;
-			}
-
-			.article-card.medium .article-image {
-				height: 200px;
-			}
-
-			.article-card.medium .article-title {
-				font-size: 1.4rem;
-				-webkit-line-clamp: 2;
-			}
-
-		.article-card.medium .article-summary {
-			font-size: 1rem;
-			-webkit-line-clamp: 3;
-			min-height: calc(1.6em * 3);
-		}
-
-			/* Responsive */
 		@media (max-width: 768px) {
-			.navbar {
-				padding: 1rem;
-			}
-
-			.navbar-nav {
-				display: none;
-			}
-
-			.hero {
-				min-height: 50vh;
-			}
-
-			.hero-buttons {
-				flex-direction: column;
-				align-items: center;
-			}
-
-			.btn-hero {
-				width: 100%;
-				max-width: 280px;
-				justify-content: center;
-			}
-
-			.articles-grid {
-				grid-template-columns: 1fr;
-			}
-
-			.articles-row-three {
-				grid-template-columns: 1fr;
-			}
-
-			.article-card.featured {
-				height: auto;
-			}
-
-			.article-card.medium {
-				height: auto;
-			}
-
-			.container {
+			.page-container {
 				padding: 0 1rem;
 			}
 		}
 	</style>
 
-	{websiteData ? (
-		<>
-			<!-- Navigation Header -->
-			<nav class="navbar">
-				<a href={`/${activeLocale}`} class="navbar-brand">
-					{brandLogoUrl && (
-						<img
-							src={brandLogoUrl}
-							alt={brandLogo?.alternativeText || `${brandDisplayName} logo`}
-							style="height: 24px;"
-						/>
-					)}
-					{brandDisplayName}
-				</a>
+		{websiteData ? (
+			<>
+				<NavigationBar
+					homeHref={`/${activeLocale}`}
+					brandLogoUrl={brandLogoUrl}
+					brandLogoAlt={brandLogo?.alternativeText || `${brandDisplayName} logo`}
+					brandDisplayName={brandDisplayName}
+					navLinks={navLinks}
+					availableLocales={supportedLocales}
+					currentLocale={activeLocale}
+					currentPath={Astro.url.pathname}
+					accentColor={brandColor}
+				/>
 
-				<ul class="navbar-nav">
-					{primaryNav.length > 0
-						? primaryNav.map((item) => {
-							const href = resolveNavHref(item, activeLocale);
-							const isExternal = item.linkType === 'external_url';
-							const openInNewTab = Boolean(item.openInNewTab || isExternal);
-							return (
-								<li>
-									<a
-										href={href}
-										target={openInNewTab ? '_blank' : undefined}
-										rel={openInNewTab ? 'noopener noreferrer' : undefined}
-									>
-										{item.label}
-									</a>
-								</li>
-							);
-						})
-						: tags.slice(0, 5).map(tag => (
-							<li><a href={`/${activeLocale}/tag/${tag.slug}`}>{tag.name}</a></li>
-						))}
-				</ul>
+				<HeroSection
+					title={brandDisplayName}
+					tagline={tagline}
+					backgroundUrl={heroBackgroundUrl}
+					primaryColor={brandColor}
+					secondaryColor={secondaryColor}
+					srText={heroBackgroundUrl ? heroImageAlt : undefined}
+					ctaLabel={readMoreLabel}
+					ctaHref="#articles"
+				/>
 
-				<div class="navbar-actions">
-					{supportedLocales.length > 0 && (
-						<LanguageSelector
-							availableLocales={supportedLocales}
-							currentLang={activeLocale}
-							currentPath={Astro.url.pathname}
-						/>
-					)}
-				</div>
-			</nav>
+				<div class="page-container">
+					<section class="section" id="articles">
+						<h2 class="section-title">{sectionTitle}</h2>
+						{sectionSubtitle && (
+							<p class="section-subtitle">{sectionSubtitle}</p>
+						)}
 
-			<!-- Hero Section -->
-			<section class="hero" style={heroBackgroundStyle}>
-				{heroBackgroundUrl && <span class="sr-only">{heroImageAlt}</span>}
-				<div class="hero-content">
-					<h1>{brandDisplayName}</h1>
-					{tagline && <p>{tagline}</p>}
-					<div class="hero-buttons">
-						<a href="#articles" class="btn-hero btn-primary">
-							{readMoreLabel}
-							<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-								<path d="m9 18 6-6-6-6"/>
-							</svg>
-						</a>
-					</div>
-				</div>
-			</section>
-
-			<!-- Main Content -->
-			<div class="container">
-
-
-				<!-- Articles Section -->
-				<section class="section" id="articles">
-					<h2 class="section-title">{sectionTitle}</h2>
-					{sectionSubtitle && (
-						<p class="section-subtitle">{sectionSubtitle}</p>
-					)}
-
-					{articles.length > 0 ? (
-						<div class="articles-grid">
-						<!-- Featured article on the left -->
-							{articles[0] && (
-									<article class="article-card featured">
-										<img
-										src={getCoverImageUrl(articles[0].coverImage) ?? '/images/placeholder.jpg'}
-										alt={articles[0].coverImage?.alternativeText || articles[0].title}
-										class="article-image"
-									/>
-									<div class="article-content">
-										<div class="article-meta">
-											<span>📅 {new Date(articles[0].updatedAt).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}</span>
-											{articles[0].readingTime && <span>⏱ {articles[0].readingTime} min read</span>}
-											{articles[0].tags?.[0] && <span>🏷️ {articles[0].tags[0].name}</span>}
-										</div>
-										<h3 class="article-title">
-											<a href={`/articles/${articles[0].slug}`}>{articles[0].title}</a>
-										</h3>
-										<p class={`article-summary${articles[0].summary ? '' : ' placeholder'}`}>
-											{articles[0].summary || summaryFallback}
-										</p>
-										<a href={`/${activeLocale}/articles/${articles[0].slug}`} class="read-more">
-											{readMoreLabel}
-											<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-												<path d="m9 18 6-6-6-6"/>
-											</svg>
-										</a>
-									</div>
-								</article>
-							)}
-
-						<!-- Right column with two smaller articles -->
-							<div class="articles-right-column">
-								{articles.slice(1, 3).map((article) => (
-									<article class="article-card small">
-										<img
-											src={getCoverImageUrl(article.coverImage) ?? '/images/placeholder.jpg'}
-											alt={article.coverImage?.alternativeText || article.title}
-											class="article-image"
-										/>
-										<div class="article-content">
-											<div class="article-meta">
-												<span>📅 {new Date(article.updatedAt).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}</span>
-												{article.readingTime && <span>⏱ {article.readingTime} min read</span>}
-												{article.tags?.[0] && <span>🏷️ {article.tags[0].name}</span>}
-											</div>
-											<h3 class="article-title">
-											<a href={`/${activeLocale}/articles/${article.slug}`}>{article.title}</a>
-											</h3>
-											<p class={`article-summary${article.summary ? '' : ' placeholder'}`}>
-												{article.summary || summaryFallback}
-											</p>
-											<a href={`/${activeLocale}/articles/${article.slug}`} class="read-more">
-												{readMoreLabel}
-												<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-													<path d="m9 18 6-6-6-6"/>
-												</svg>
-											</a>
-										</div>
-									</article>
-								))}
-							</div>
-						</div>
-
-						<!-- Row of 3 articles -->
-						{articles.length > 3 && (
-							<div class="articles-row-three">
-								{articles.slice(3, 6).map((article) => (
-									<article class="article-card medium">
-										<img
-											src={getCoverImageUrl(article.coverImage) ?? '/images/placeholder.jpg'}
-											alt={article.coverImage?.alternativeText || article.title}
-											class="article-image"
-										/>
-										<div class="article-content">
-											<div class="article-meta">
-												<span>📅 {new Date(article.updatedAt).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}</span>
-												{article.readingTime && <span>⏱ {article.readingTime} min read</span>}
-												{article.tags?.[0] && <span>🏷️ {article.tags[0].name}</span>}
-											</div>
-											<h3 class="article-title">
-											<a href={`/${activeLocale}/articles/${article.slug}`}>{article.title}</a>
-											</h3>
-											<p class={`article-summary${article.summary ? '' : ' placeholder'}`}>
-												{article.summary || summaryFallback}
-											</p>
-											<a href={`/${activeLocale}/articles/${article.slug}`} class="read-more">
-												{readMoreLabel}
-												<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-													<path d="m9 18 6-6-6-6"/>
-												</svg>
-											</a>
-										</div>
-									</article>
-								))}
+						{articles.length > 0 ? (
+							<ArticleGrid
+								articles={articles}
+								locale={activeLocale}
+								readMoreLabel={readMoreLabel}
+								summaryFallback={summaryFallback}
+							/>
+						) : (
+							<div class="empty-state">
+								<h3>{brandDisplayName}</h3>
+								<p>{tagline || searchPlaceholder}</p>
 							</div>
 						)}
-					) : (
-						<div style="text-align: center; padding: 3rem; color: #6b7280;">
-							<h3>{brandDisplayName}</h3>
-							<p>{tagline || searchPlaceholder}</p>
-						</div>
-					)}
-				</section>
-			</div>
-		</>
-	) : (
-		<!-- Fallback for no website data -->
-		<div class="container" style="text-align: center; padding: 5rem 2rem;">
-			<svg width="80" height="80" viewBox="0 0 24 24" fill="none" stroke="var(--orange)" stroke-width="1.5" style="margin-bottom: 2rem;">
-				<path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/>
-				<line x1="12" y1="9" x2="12" y2="13"/>
-				<line x1="12" y1="17" x2="12.01" y2="17"/>
-			</svg>
-			<h1 style="color: var(--text); margin-bottom: 1rem;">Welcome to Astro</h1>
-			<div style="background: var(--surface); padding: 2rem; border-radius: var(--border-radius); border-left: 4px solid var(--orange); max-width: 600px; margin: 0 auto;">
-				<h3 style="color: var(--orange); margin-bottom: 0.5rem;">Configuration Required</h3>
-				<p style="color: var(--text-secondary); line-height: 1.6;">
-					Unable to load website data from CMS. Please check your environment variables and ensure your CMS is properly configured.
-				</p>
-			</div>
-		</div>
-	)}
+					</section>
+				</div>
+			</>
+		) : (
+			<NoWebsiteFallback />
+		)}
 
 	<DebugPanel
 		websiteData={websiteData}


### PR DESCRIPTION
  - Extracted navigation, hero, article grid/cards, and fallback panels into dedicated components under src/components, keeping [lang]/index.astro focused on data orchestration.
  - Normalized media URLs and pass CMS-driven props into the new components, including locale-aware links and system labels.
  - Updated AGENTS.md to document the component-first structure for future feature work.